### PR TITLE
issue/973: 添加QY和NV上的per_tensor_fp8,per_token_fp8的量化和反量化算子

### DIFF
--- a/include/infiniop/ops/dequant/per_tensor_dequant_fp8.h
+++ b/include/infiniop/ops/dequant/per_tensor_dequant_fp8.h
@@ -1,0 +1,28 @@
+#ifndef __INFINIOP_PER_TENSOR_DEQUANT_FP8_API_H__
+#define __INFINIOP_PER_TENSOR_DEQUANT_FP8_API_H__
+
+#include "../../operator_descriptor.h"
+
+typedef InfiniopDescriptor *infiniopPerTensorDequantF8Descriptor_t;
+
+__C __export infiniStatus_t infiniopCreatePerTensorDequantF8Descriptor(infiniopHandle_t handle,
+                                                                       infiniopPerTensorDequantF8Descriptor_t *desc_ptr,
+                                                                       infiniopTensorDescriptor_t x_desc,
+                                                                       infiniopTensorDescriptor_t x_packed_desc,
+                                                                       infiniopTensorDescriptor_t x_scale_desc,
+                                                                       infiniopTensorDescriptor_t x_zero_desc);
+
+__C __export infiniStatus_t infiniopGetPerTensorDequantF8WorkspaceSize(infiniopPerTensorDequantF8Descriptor_t desc, size_t *size);
+
+__C __export infiniStatus_t infiniopPerTensorDequantF8(infiniopPerTensorDequantF8Descriptor_t desc,
+                                                       void *workspace,
+                                                       size_t workspace_size,
+                                                       void *x,
+                                                       const void *x_packed,
+                                                       const void *x_scale,
+                                                       const void *x_zero,
+                                                       void *stream);
+
+__C __export infiniStatus_t infiniopDestroyPerTensorDequantF8Descriptor(infiniopPerTensorDequantF8Descriptor_t desc);
+
+#endif

--- a/include/infiniop/ops/dequant/per_token_dequant_fp8.h
+++ b/include/infiniop/ops/dequant/per_token_dequant_fp8.h
@@ -1,0 +1,28 @@
+#ifndef __INFINIOP_PER_TOKEN_DEQUANT_FP8_API_H__
+#define __INFINIOP_PER_TOKEN_DEQUANT_FP8_API_H__
+
+#include "../../operator_descriptor.h"
+
+typedef InfiniopDescriptor *infiniopPerTokenDequantF8Descriptor_t;
+
+__C __export infiniStatus_t infiniopCreatePerTokenDequantF8Descriptor(infiniopHandle_t handle,
+                                                                      infiniopPerTokenDequantF8Descriptor_t *desc_ptr,
+                                                                      infiniopTensorDescriptor_t x_desc,
+                                                                      infiniopTensorDescriptor_t x_packed_desc,
+                                                                      infiniopTensorDescriptor_t x_scale_desc,
+                                                                      infiniopTensorDescriptor_t x_zero_desc);
+
+__C __export infiniStatus_t infiniopGetPerTokenDequantF8WorkspaceSize(infiniopPerTokenDequantF8Descriptor_t desc, size_t *size);
+
+__C __export infiniStatus_t infiniopPerTokenDequantF8(infiniopPerTokenDequantF8Descriptor_t desc,
+                                                      void *workspace,
+                                                      size_t workspace_size,
+                                                      void *x,
+                                                      const void *x_packed,
+                                                      const void *x_scale,
+                                                      const void *x_zero,
+                                                      void *stream);
+
+__C __export infiniStatus_t infiniopDestroyPerTokenDequantF8Descriptor(infiniopPerTokenDequantF8Descriptor_t desc);
+
+#endif

--- a/include/infiniop/ops/quant/per_tensor_quant_fp8.h
+++ b/include/infiniop/ops/quant/per_tensor_quant_fp8.h
@@ -10,8 +10,7 @@ __C __export infiniStatus_t infiniopCreatePerTensorQuantF8Descriptor(infiniopHan
                                                                      infiniopTensorDescriptor_t x_packed_desc,
                                                                      infiniopTensorDescriptor_t x_scale_desc,
                                                                      infiniopTensorDescriptor_t x_zero_desc,
-                                                                     infiniopTensorDescriptor_t x_desc,
-                                                                     bool is_static);
+                                                                     infiniopTensorDescriptor_t x_desc);
 
 __C __export infiniStatus_t infiniopGetPerTensorQuantF8WorkspaceSize(infiniopPerTensorQuantF8Descriptor_t desc, size_t *size);
 
@@ -22,6 +21,7 @@ __C __export infiniStatus_t infiniopPerTensorQuantF8(infiniopPerTensorQuantF8Des
                                                      void *x_scale,
                                                      void *x_zero,
                                                      const void *x,
+                                                     const bool is_static,
                                                      void *stream);
 
 __C __export infiniStatus_t infiniopDestroyPerTensorQuantF8Descriptor(infiniopPerTensorQuantF8Descriptor_t desc);

--- a/include/infiniop/ops/quant/per_tensor_quant_fp8.h
+++ b/include/infiniop/ops/quant/per_tensor_quant_fp8.h
@@ -1,0 +1,29 @@
+#ifndef __INFINIOP_PER_TENSOR_QUANT_FP8_API_H__
+#define __INFINIOP_PER_TENSOR_QUANT_FP8_API_H__
+
+#include "../../operator_descriptor.h"
+
+typedef InfiniopDescriptor *infiniopPerTensorQuantF8Descriptor_t;
+
+__C __export infiniStatus_t infiniopCreatePerTensorQuantF8Descriptor(infiniopHandle_t handle,
+                                                                     infiniopPerTensorQuantF8Descriptor_t *desc_ptr,
+                                                                     infiniopTensorDescriptor_t x_packed_desc,
+                                                                     infiniopTensorDescriptor_t x_scale_desc,
+                                                                     infiniopTensorDescriptor_t x_zero_desc,
+                                                                     infiniopTensorDescriptor_t x_desc,
+                                                                     bool is_static);
+
+__C __export infiniStatus_t infiniopGetPerTensorQuantF8WorkspaceSize(infiniopPerTensorQuantF8Descriptor_t desc, size_t *size);
+
+__C __export infiniStatus_t infiniopPerTensorQuantF8(infiniopPerTensorQuantF8Descriptor_t desc,
+                                                     void *workspace,
+                                                     size_t workspace_size,
+                                                     void *x_packed,
+                                                     void *x_scale,
+                                                     void *x_zero,
+                                                     const void *x,
+                                                     void *stream);
+
+__C __export infiniStatus_t infiniopDestroyPerTensorQuantF8Descriptor(infiniopPerTensorQuantF8Descriptor_t desc);
+
+#endif

--- a/include/infiniop/ops/quant/per_token_quant_fp8.h
+++ b/include/infiniop/ops/quant/per_token_quant_fp8.h
@@ -1,0 +1,28 @@
+#ifndef __INFINIOP_PER_TOKEN_QUANT_FP8_API_H__
+#define __INFINIOP_PER_TOKEN_QUANT_FP8_API_H__
+
+#include "../../operator_descriptor.h"
+
+typedef InfiniopDescriptor *infiniopPerTokenQuantF8Descriptor_t;
+
+__C __export infiniStatus_t infiniopCreatePerTokenQuantF8Descriptor(infiniopHandle_t handle,
+                                                                    infiniopPerTokenQuantF8Descriptor_t *desc_ptr,
+                                                                    infiniopTensorDescriptor_t x_packed_desc,
+                                                                    infiniopTensorDescriptor_t x_scale_desc,
+                                                                    infiniopTensorDescriptor_t x_zero_desc,
+                                                                    infiniopTensorDescriptor_t x_desc);
+
+__C __export infiniStatus_t infiniopGetPerTokenQuantF8WorkspaceSize(infiniopPerTokenQuantF8Descriptor_t desc, size_t *size);
+
+__C __export infiniStatus_t infiniopPerTokenQuantF8(infiniopPerTokenQuantF8Descriptor_t desc,
+                                                    void *workspace,
+                                                    size_t workspace_size,
+                                                    void *x_packed,
+                                                    void *x_scale,
+                                                    void *x_zero,
+                                                    const void *x,
+                                                    void *stream);
+
+__C __export infiniStatus_t infiniopDestroyPerTokenQuantF8Descriptor(infiniopPerTokenQuantF8Descriptor_t desc);
+
+#endif

--- a/src/infiniop/ops/dequant/per_tensor_dequant_fp8/cuda/kernel.cuh
+++ b/src/infiniop/ops/dequant/per_tensor_dequant_fp8/cuda/kernel.cuh
@@ -1,0 +1,15 @@
+#ifndef __PER_TENSOR_DEQUANT_FP8_KERNEL_CUH__
+#define __PER_TENSOR_DEQUANT_FP8_KERNEL_CUH__
+
+template <typename Tin, typename Tout>
+__device__ void
+perTensorDequantFp8SymKernel(Tout *x, const Tin *x_packed, const float *x_scale, int num_elements) {
+    unsigned int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    const int grid_size = blockDim.x * gridDim.x;
+    for (int i = gid; i < num_elements; i += grid_size) {
+        float val = static_cast<float>(x_packed[i]) * x_scale[0];
+        x[i] = static_cast<Tout>(val);
+    }
+}
+
+#endif // __PER_TENSOR_DEQUANT_FP8_KERNEL_CUH__

--- a/src/infiniop/ops/dequant/per_tensor_dequant_fp8/info.h
+++ b/src/infiniop/ops/dequant/per_tensor_dequant_fp8/info.h
@@ -1,0 +1,54 @@
+#ifndef __PER_TENSOR_DEQUANT_FP8_INFO_H__
+#define __PER_TENSOR_DEQUANT_FP8_INFO_H__
+
+#include "../../../../utils.h"
+#include "../../../operator.h"
+#include "../../../tensor.h"
+
+namespace op::per_tensor_dequant_fp8 {
+
+class PerTensorDequantF8Info {
+private:
+    PerTensorDequantF8Info() = default;
+
+public:
+    infiniDtype_t dtype, packed_type;
+    int64_t num_elements;
+
+    static utils::Result<PerTensorDequantF8Info> createPerTensorDequantF8Info(
+        infiniopTensorDescriptor_t x_desc,
+        infiniopTensorDescriptor_t x_packed_desc,
+        infiniopTensorDescriptor_t x_scale_desc,
+        infiniopTensorDescriptor_t x_zero_desc) {
+
+        CHECK_OR_RETURN(
+            x_packed_desc != nullptr && x_scale_desc != nullptr && x_desc != nullptr,
+            INFINI_STATUS_NULL_POINTER);
+
+        const infiniDtype_t dtype = x_desc->dtype();
+        const infiniDtype_t packed_type = x_packed_desc->dtype();
+
+        CHECK_DTYPE(dtype, INFINI_DTYPE_F16, INFINI_DTYPE_BF16, INFINI_DTYPE_F32);
+        CHECK_DTYPE(packed_type, INFINI_DTYPE_F8);
+
+        auto shape = x_desc->shape();
+        CHECK_SAME_SHAPE(shape, x_packed_desc->shape());
+
+        auto ndim = x_desc->ndim();
+
+        int64_t num_elements = 1;
+        for (int i = 0; i < (int)ndim; i++) {
+            num_elements *= static_cast<int64_t>(shape[i]);
+        }
+
+        return utils::Result<PerTensorDequantF8Info>(PerTensorDequantF8Info{
+            dtype,
+            packed_type,
+            num_elements,
+        });
+    }
+};
+
+} // namespace op::per_tensor_dequant_fp8
+
+#endif //  __PER_TENSOR_DEQUANT_FP8_INFO_H__

--- a/src/infiniop/ops/dequant/per_tensor_dequant_fp8/nvidia/per_tensor_dequant_fp8_nvidia.cu
+++ b/src/infiniop/ops/dequant/per_tensor_dequant_fp8/nvidia/per_tensor_dequant_fp8_nvidia.cu
@@ -1,0 +1,101 @@
+#include "../../../../devices/nvidia/nvidia_common.cuh"
+#include "per_tensor_dequant_fp8_nvidia.cuh"
+
+#include "../../../../devices/nvidia/nvidia_kernel_common.cuh"
+#include "../../../../reduce/cuda/reduce.cuh"
+#include <cub/block/block_reduce.cuh>
+
+#include "../cuda/kernel.cuh"
+
+template <typename Tin, typename Tout>
+INFINIOP_CUDA_KERNEL perTensorDequantFp8Sym(
+    Tout *x, const Tin *x_packed, const float *x_scale, int num_elements) {
+    perTensorDequantFp8SymKernel<Tin, Tout>(
+        x,
+        x_packed,
+        x_scale,
+        num_elements);
+}
+
+namespace op::per_tensor_dequant_fp8::nvidia {
+
+struct Descriptor::Opaque {
+    std::shared_ptr<device::nvidia::Handle::Internal> internal;
+};
+
+Descriptor::~Descriptor() {
+    delete _opaque;
+}
+
+infiniStatus_t Descriptor::create(
+    infiniopHandle_t handle, Descriptor **desc_ptr,
+    infiniopTensorDescriptor_t x_desc,
+    infiniopTensorDescriptor_t x_packed_desc,
+    infiniopTensorDescriptor_t x_scale_desc,
+    infiniopTensorDescriptor_t x_zero_desc) {
+
+    auto info = PerTensorDequantF8Info::createPerTensorDequantF8Info(x_desc, x_packed_desc, x_scale_desc, x_zero_desc);
+
+    CHECK_RESULT(info);
+
+    *desc_ptr = new Descriptor(
+        new Opaque{reinterpret_cast<device::nvidia::Handle *>(handle)->internal()},
+        info.take(), 0, handle->device, handle->device_id);
+
+    return INFINI_STATUS_SUCCESS;
+}
+
+template <unsigned int BLOCK_SIZE, typename Tdata>
+infiniStatus_t perTensorDequantFp8(const PerTensorDequantF8Info &info, Tdata *x, const __nv_fp8_e4m3 *x_packed, const float *x_scale, const float *x_zero, cudaStream_t stream) {
+    int num_elements = static_cast<int>(info.num_elements);
+
+#ifdef ENABLE_NVIDIA_API
+    constexpr unsigned int block_size = 256;
+#else
+    constexpr unsigned int block_size = BLOCK_SIZE;
+#endif
+    int num_blocks = min((static_cast<int>(num_elements) + block_size - 1) / block_size, 1024);
+
+    dim3 grid(num_blocks);
+    dim3 block(block_size);
+    if (x_zero == nullptr) {
+
+        perTensorDequantFp8Sym<__nv_fp8_e4m3, Tdata>
+            <<<grid, block, 0, stream>>>(x, x_packed, x_scale, num_elements);
+    } else {
+        return INFINI_STATUS_BAD_PARAM;
+    }
+
+    return INFINI_STATUS_SUCCESS;
+}
+
+infiniStatus_t Descriptor::calculate(void *workspace, size_t workspace_size,
+                                     void *x, const void *x_packed, const void *x_scale, const void *x_zero,
+                                     void *stream_) const {
+    cudaStream_t stream = (cudaStream_t)stream_;
+#define DEQUANT(BLOCK_SIZE, TDATA) \
+    perTensorDequantFp8<BLOCK_SIZE, TDATA>(_info, (TDATA *)x, (const __nv_fp8_e4m3 *)x_packed, (const float *)x_scale, (const float *)x_zero, stream)
+#define DEQUANT_WITH_BLOCK_SIZE(BLOCK_SIZE)            \
+    {                                                  \
+        if (_info.dtype == INFINI_DTYPE_F16)           \
+            return DEQUANT(BLOCK_SIZE, half);          \
+        else if (_info.dtype == INFINI_DTYPE_F32)      \
+            return DEQUANT(BLOCK_SIZE, float);         \
+        else if (_info.dtype == INFINI_DTYPE_BF16)     \
+            return DEQUANT(BLOCK_SIZE, __nv_bfloat16); \
+        else                                           \
+            return INFINI_STATUS_BAD_TENSOR_DTYPE;     \
+    }
+    if (_opaque->internal->maxThreadsPerBlock() == CUDA_BLOCK_SIZE_1024) {
+        DEQUANT_WITH_BLOCK_SIZE(CUDA_BLOCK_SIZE_1024)
+    } else if (_opaque->internal->maxThreadsPerBlock() == CUDA_BLOCK_SIZE_512) {
+        DEQUANT_WITH_BLOCK_SIZE(CUDA_BLOCK_SIZE_512)
+    } else if (_opaque->internal->maxThreadsPerBlock() == CUDA_BLOCK_SIZE_4096) {
+        DEQUANT_WITH_BLOCK_SIZE(CUDA_BLOCK_SIZE_4096)
+    } else {
+        return INFINI_STATUS_DEVICE_ARCHITECTURE_NOT_SUPPORTED;
+    }
+    return INFINI_STATUS_SUCCESS;
+}
+
+} // namespace op::per_tensor_dequant_fp8::nvidia

--- a/src/infiniop/ops/dequant/per_tensor_dequant_fp8/nvidia/per_tensor_dequant_fp8_nvidia.cuh
+++ b/src/infiniop/ops/dequant/per_tensor_dequant_fp8/nvidia/per_tensor_dequant_fp8_nvidia.cuh
@@ -1,0 +1,7 @@
+#ifndef __PER_TENSOR_DEQUANT_FP8_NVIDIA_API_H__
+#define __PER_TENSOR_DEQUANT_FP8_NVIDIA_API_H__
+#include "../per_tensor_dequant_fp8.h"
+
+DESCRIPTOR(nvidia)
+
+#endif // __PER_TENSOR_DEQUANT_FP8_NVIDIA_API_H__

--- a/src/infiniop/ops/dequant/per_tensor_dequant_fp8/operator.cc
+++ b/src/infiniop/ops/dequant/per_tensor_dequant_fp8/operator.cc
@@ -1,0 +1,98 @@
+#include "../../../operator.h"
+#include "../../../handle.h"
+#include "infiniop/ops/dequant/per_tensor_dequant_fp8.h"
+
+#if defined(ENABLE_NVIDIA_API) || defined(ENABLE_QY_API)
+#include "nvidia/per_tensor_dequant_fp8_nvidia.cuh"
+#endif
+
+__C infiniStatus_t infiniopCreatePerTensorDequantF8Descriptor(infiniopHandle_t handle,
+                                                              infiniopPerTensorDequantF8Descriptor_t *desc_ptr,
+                                                              infiniopTensorDescriptor_t x_desc,
+                                                              infiniopTensorDescriptor_t x_packed_desc,
+                                                              infiniopTensorDescriptor_t x_scale_desc,
+                                                              infiniopTensorDescriptor_t x_zero_desc) {
+#define CREATE(CASE, NAMESPACE)                                                               \
+    case CASE:                                                                                \
+        return op::per_tensor_dequant_fp8::NAMESPACE::Descriptor::create(                     \
+            handle,                                                                           \
+            reinterpret_cast<op::per_tensor_dequant_fp8::NAMESPACE::Descriptor **>(desc_ptr), \
+            x_desc,                                                                           \
+            x_packed_desc,                                                                    \
+            x_scale_desc,                                                                     \
+            x_zero_desc);
+    switch (handle->device) {
+#ifdef ENABLE_NVIDIA_API
+        CREATE(INFINI_DEVICE_NVIDIA, nvidia)
+#endif
+#ifdef ENABLE_QY_API
+        CREATE(INFINI_DEVICE_QY, nvidia)
+#endif
+    default:
+        return INFINI_STATUS_DEVICE_TYPE_NOT_SUPPORTED;
+    }
+#undef CREATE
+}
+
+__C infiniStatus_t infiniopGetPerTensorDequantF8WorkspaceSize(infiniopPerTensorDequantF8Descriptor_t desc, size_t *size) {
+    switch (desc->device_type) {
+#define GET(CASE, NAMESPACE)                                                                                     \
+    case CASE:                                                                                                   \
+        *size = reinterpret_cast<op::per_tensor_dequant_fp8::NAMESPACE::Descriptor *>(desc)->minWorkspaceSize(); \
+        return INFINI_STATUS_SUCCESS;
+#ifdef ENABLE_NVIDIA_API
+        GET(INFINI_DEVICE_NVIDIA, nvidia)
+#endif
+#ifdef ENABLE_QY_API
+        GET(INFINI_DEVICE_QY, nvidia)
+#endif
+    default:
+        return INFINI_STATUS_DEVICE_TYPE_NOT_SUPPORTED;
+    }
+#undef GET
+}
+
+__C infiniStatus_t infiniopPerTensorDequantF8(infiniopPerTensorDequantF8Descriptor_t desc,
+                                              void *workspace,
+                                              size_t workspace_size,
+                                              void *x,
+                                              const void *x_packed,
+                                              const void *x_scale,
+                                              const void *x_zero,
+                                              void *stream) {
+#define DEQUANT(CASE, NAMESPACE)                                                                       \
+    case CASE:                                                                                         \
+        return reinterpret_cast<op::per_tensor_dequant_fp8::NAMESPACE::Descriptor *>(desc)->calculate( \
+            workspace, workspace_size, x, x_packed, x_scale, x_zero, stream);
+
+    switch (desc->device_type) {
+#ifdef ENABLE_NVIDIA_API
+        DEQUANT(INFINI_DEVICE_NVIDIA, nvidia)
+#endif
+#ifdef ENABLE_QY_API
+        DEQUANT(INFINI_DEVICE_QY, nvidia)
+#endif
+    default:
+        return INFINI_STATUS_DEVICE_TYPE_NOT_SUPPORTED;
+    }
+#undef DEQUANT
+}
+
+__C infiniStatus_t infiniopDestroyPerTensorDequantF8Descriptor(infiniopPerTensorDequantF8Descriptor_t desc) {
+#define DESTROY(CASE, NAMESPACE)                                                            \
+    case CASE:                                                                              \
+        delete reinterpret_cast<op::per_tensor_dequant_fp8::NAMESPACE::Descriptor *>(desc); \
+        return INFINI_STATUS_SUCCESS;
+
+    switch (desc->device_type) {
+#ifdef ENABLE_NVIDIA_API
+        DESTROY(INFINI_DEVICE_NVIDIA, nvidia)
+#endif
+#ifdef ENABLE_QY_API
+        DESTROY(INFINI_DEVICE_QY, nvidia)
+#endif
+    default:
+        return INFINI_STATUS_DEVICE_TYPE_NOT_SUPPORTED;
+    }
+#undef DESTROY
+}

--- a/src/infiniop/ops/dequant/per_tensor_dequant_fp8/per_tensor_dequant_fp8.h
+++ b/src/infiniop/ops/dequant/per_tensor_dequant_fp8/per_tensor_dequant_fp8.h
@@ -1,0 +1,40 @@
+#ifndef __PER_TENSOR_DEQUANT_FP8_H__
+#define __PER_TENSOR_DEQUANT_FP8_H__
+
+#include "../../../operator.h"
+#include "info.h"
+
+#define DESCRIPTOR(NAMESPACE)                                                                            \
+                                                                                                         \
+    namespace op::per_tensor_dequant_fp8::NAMESPACE {                                                    \
+    class Descriptor final : public InfiniopDescriptor {                                                 \
+        struct Opaque;                                                                                   \
+        Opaque *_opaque;                                                                                 \
+        PerTensorDequantF8Info _info;                                                                    \
+        size_t _workspace_size;                                                                          \
+                                                                                                         \
+        Descriptor(Opaque *opaque, PerTensorDequantF8Info info,                                          \
+                   size_t workspace_size,                                                                \
+                   infiniDevice_t device_type, int device_id)                                            \
+            : InfiniopDescriptor{device_type, device_id},                                                \
+              _opaque(opaque), _info(info), _workspace_size(workspace_size) {}                           \
+                                                                                                         \
+    public:                                                                                              \
+        ~Descriptor();                                                                                   \
+                                                                                                         \
+        size_t minWorkspaceSize() const { return _workspace_size; }                                      \
+                                                                                                         \
+        static infiniStatus_t create(                                                                    \
+            infiniopHandle_t handle, Descriptor **desc_ptr,                                              \
+            infiniopTensorDescriptor_t x_desc,                                                           \
+            infiniopTensorDescriptor_t x_packed_desc,                                                    \
+            infiniopTensorDescriptor_t x_scale_desc,                                                     \
+            infiniopTensorDescriptor_t x_zero_desc);                                                     \
+                                                                                                         \
+        infiniStatus_t calculate(                                                                        \
+            void *workspace, size_t workspace_size,                                                      \
+            void *x, const void *x_packed, const void *x_scale, const void *x_zero, void *stream) const; \
+    };                                                                                                   \
+    }
+
+#endif // __PER_TENSOR_DEQUANT_FP8_H__

--- a/src/infiniop/ops/dequant/per_token_dequant_fp8/cuda/kernel.cuh
+++ b/src/infiniop/ops/dequant/per_token_dequant_fp8/cuda/kernel.cuh
@@ -1,0 +1,36 @@
+#ifndef __PER_TOKEN_DEQUANT_FP8_KERNEL_CUH__
+#define __PER_TOKEN_DEQUANT_FP8_KERNEL_CUH__
+
+static constexpr int kWarpSize = 32;
+
+template <typename Tin, typename Tout, unsigned int BLOCK_SIZE>
+__device__ void
+blockPerTokenDequantFp8SymKernel(Tout *x, const Tin *x_packed, const float *x_scale, int hidden_dim, int num_tokens) {
+    const int token_idx = blockIdx.x;
+    if (token_idx >= num_tokens) {
+        return;
+    }
+    int tid = token_idx * hidden_dim;
+    for (int i = threadIdx.x; i < hidden_dim; i += BLOCK_SIZE) {
+        float val = static_cast<float>(x_packed[tid + i]) * x_scale[token_idx];
+        x[tid + i] = static_cast<Tout>(val);
+    }
+}
+
+template <typename Tin, typename Tout, unsigned int BLOCK_SIZE, int kTokensPerCTA = 8>
+__device__ void
+warpPerTokenDequantFp8SymKernel(Tout *x, const Tin *x_packed, const float *x_scale, int hidden_dim, int num_tokens) {
+    const int warp_id = threadIdx.x / kWarpSize;       // 0‑7  (8 warps)
+    const int lane_id = threadIdx.x & (kWarpSize - 1); // 0‑31
+    const int token_id = blockIdx.x * kTokensPerCTA + warp_id;
+    if (token_id >= num_tokens) {
+        return;
+    }
+    int tid = token_id * hidden_dim;
+    for (int i = lane_id; i < hidden_dim; i += kWarpSize) {
+        float val = static_cast<float>(x_packed[tid + i]) * x_scale[token_id];
+        x[tid + i] = static_cast<Tout>(val);
+    }
+}
+
+#endif // __PER_TOKEN_DEQUANT_FP8_KERNEL_CUH__

--- a/src/infiniop/ops/dequant/per_token_dequant_fp8/info.h
+++ b/src/infiniop/ops/dequant/per_token_dequant_fp8/info.h
@@ -1,0 +1,60 @@
+#ifndef __PER_TOKEN_DEQUANT_FP8_INFO_H__
+#define __PER_TOKEN_DEQUANT_FP8_INFO_H__
+
+#include "../../../../utils.h"
+#include "../../../operator.h"
+#include "../../../tensor.h"
+
+namespace op::per_token_dequant_fp8 {
+
+class PerTokenDequantF8Info {
+private:
+    PerTokenDequantF8Info() = default;
+
+public:
+    infiniDtype_t dtype, packed_type;
+    int64_t hidden_dim, num_tokens;
+
+    static utils::Result<PerTokenDequantF8Info> createPerTokenDequantF8Info(
+        infiniopTensorDescriptor_t x_desc,
+        infiniopTensorDescriptor_t x_packed_desc,
+        infiniopTensorDescriptor_t x_scale_desc,
+        infiniopTensorDescriptor_t x_zero_desc) {
+
+        CHECK_OR_RETURN(
+            x_packed_desc != nullptr && x_scale_desc != nullptr && x_desc != nullptr,
+            INFINI_STATUS_NULL_POINTER);
+
+        const infiniDtype_t dtype = x_desc->dtype();
+        const infiniDtype_t packed_type = x_packed_desc->dtype();
+
+        CHECK_DTYPE(dtype, INFINI_DTYPE_F16, INFINI_DTYPE_BF16, INFINI_DTYPE_F32);
+        CHECK_DTYPE(packed_type, INFINI_DTYPE_F8);
+
+        auto shape = x_desc->shape();
+        CHECK_SAME_SHAPE(shape, x_packed_desc->shape());
+        CHECK_OR_RETURN(x_desc->ndim() == 2
+                            && x_packed_desc->ndim() == 2,
+                        INFINI_STATUS_BAD_TENSOR_SHAPE);
+        auto ndim = x_desc->ndim();
+
+        int64_t num_tokens = static_cast<int64_t>(shape[0]);
+        int64_t hidden_dim = static_cast<int64_t>(shape[1]);
+
+        if (hidden_dim % 4 != 0) {
+            throw std::runtime_error(
+                "Hidden dimension must be divisible by 4, got " + std::to_string(hidden_dim));
+        }
+
+        return utils::Result<PerTokenDequantF8Info>(PerTokenDequantF8Info{
+            dtype,
+            packed_type,
+            hidden_dim,
+            num_tokens,
+        });
+    }
+};
+
+} // namespace op::per_token_dequant_fp8
+
+#endif //  __PER_TOKEN_DEQUANT_FP8_INFO_H__

--- a/src/infiniop/ops/dequant/per_token_dequant_fp8/nvidia/per_token_dequant_fp8_nvidia.cu
+++ b/src/infiniop/ops/dequant/per_token_dequant_fp8/nvidia/per_token_dequant_fp8_nvidia.cu
@@ -1,0 +1,149 @@
+#include "../../../../devices/nvidia/nvidia_common.cuh"
+#include "per_token_dequant_fp8_nvidia.cuh"
+
+#include "../../../../devices/nvidia/nvidia_kernel_common.cuh"
+#include "../../../../reduce/cuda/reduce.cuh"
+#include <cub/block/block_reduce.cuh>
+
+#include "../cuda/kernel.cuh"
+
+template <typename Tin, typename Tout, unsigned int BLOCK_SIZE, int kTokensPerCTA = 8>
+INFINIOP_CUDA_KERNEL warpPerTokenDequantFp8Sym(
+    Tout *x, const Tin *x_packed, const float *x_scale, int hidden_dim, int num_tokens) {
+    warpPerTokenDequantFp8SymKernel<Tin, Tout, BLOCK_SIZE, kTokensPerCTA>(
+        x, x_packed, x_scale, hidden_dim, num_tokens);
+}
+
+template <typename Tin, typename Tout, unsigned int BLOCK_SIZE>
+INFINIOP_CUDA_KERNEL blockPerTokenDequantFp8Sym(
+    Tout *x, const Tin *x_packed, const float *x_scale, int hidden_dim, int num_tokens) {
+    blockPerTokenDequantFp8SymKernel<Tin, Tout, BLOCK_SIZE>(
+        x, x_packed, x_scale, hidden_dim, num_tokens);
+}
+
+#ifdef ENABLE_NVIDIA_API
+inline int getSMCount() {
+    int device = -1;
+    cudaGetDevice(&device);
+
+    int sm_count = 0;
+    cudaDeviceGetAttribute(
+        &sm_count,
+        cudaDevAttrMultiProcessorCount,
+        device);
+
+    return sm_count;
+}
+
+#endif
+
+namespace op::per_token_dequant_fp8::nvidia {
+
+struct Descriptor::Opaque {
+    std::shared_ptr<device::nvidia::Handle::Internal> internal;
+};
+
+Descriptor::~Descriptor() {
+    delete _opaque;
+}
+
+infiniStatus_t Descriptor::create(
+    infiniopHandle_t handle, Descriptor **desc_ptr,
+    infiniopTensorDescriptor_t x_desc,
+    infiniopTensorDescriptor_t x_packed_desc,
+    infiniopTensorDescriptor_t x_scale_desc,
+    infiniopTensorDescriptor_t x_zero_desc) {
+
+    auto info = PerTokenDequantF8Info::createPerTokenDequantF8Info(x_desc, x_packed_desc, x_scale_desc, x_zero_desc);
+
+    CHECK_RESULT(info);
+
+    *desc_ptr = new Descriptor(
+        new Opaque{reinterpret_cast<device::nvidia::Handle *>(handle)->internal()},
+        info.take(), 0, handle->device, handle->device_id);
+
+    return INFINI_STATUS_SUCCESS;
+}
+
+template <unsigned int BLOCK_SIZE, typename Tdata>
+infiniStatus_t perTokenDequantFp8(const PerTokenDequantF8Info &info, Tdata *x, const __nv_fp8_e4m3 *x_packed, const float *x_scale, const float *x_zero, cudaStream_t stream) {
+
+    int hidden_dim = static_cast<int>(info.hidden_dim);
+    int num_tokens = static_cast<int>(info.num_tokens);
+
+    const int TOKENS_PER_CTA = 8;
+#ifdef ENABLE_NVIDIA_API
+    int sm_count = getSMCount();
+    const bool use_warp_kernel = (num_tokens >= sm_count * 2 * TOKENS_PER_CTA);
+#else
+    const bool use_warp_kernel = (hidden_dim < 1024);
+#endif
+
+    if (x_zero == nullptr) {
+        if (use_warp_kernel) {
+
+            // -------- warp‑local ---------------------------------------------------
+            constexpr int THREADS = TOKENS_PER_CTA * kWarpSize; // 256
+            dim3 grid((num_tokens + TOKENS_PER_CTA - 1) / TOKENS_PER_CTA);
+            dim3 block(THREADS);
+
+            warpPerTokenDequantFp8Sym<__nv_fp8_e4m3, Tdata, THREADS, TOKENS_PER_CTA><<<grid, block, 0, stream>>>(
+                x,
+                x_packed,
+                x_scale,
+                hidden_dim,
+                num_tokens);
+        } else {
+            // -------- baseline -----------------------------------------------------
+#ifdef ENABLE_NVIDIA_API
+            constexpr unsigned int THREADS = 256;
+#else
+            constexpr unsigned int THREADS = BLOCK_SIZE;
+#endif
+            dim3 grid(num_tokens);
+            dim3 block(THREADS);
+
+            blockPerTokenDequantFp8Sym<__nv_fp8_e4m3, Tdata, THREADS><<<grid, block, 0, stream>>>(
+                x,
+                x_packed,
+                x_scale,
+                hidden_dim,
+                num_tokens);
+        }
+    } else {
+        return INFINI_STATUS_BAD_PARAM;
+    }
+
+    return INFINI_STATUS_SUCCESS;
+}
+
+infiniStatus_t Descriptor::calculate(void *workspace, size_t workspace_size,
+                                     void *x, const void *x_packed, const void *x_scale, const void *x_zero,
+                                     void *stream_) const {
+    cudaStream_t stream = (cudaStream_t)stream_;
+#define DEQUANT(BLOCK_SIZE, TDATA) \
+    perTokenDequantFp8<BLOCK_SIZE, TDATA>(_info, (TDATA *)x, (const __nv_fp8_e4m3 *)x_packed, (const float *)x_scale, (const float *)x_zero, stream)
+#define DEQUANT_WITH_BLOCK_SIZE(BLOCK_SIZE)            \
+    {                                                  \
+        if (_info.dtype == INFINI_DTYPE_F16)           \
+            return DEQUANT(BLOCK_SIZE, half);          \
+        else if (_info.dtype == INFINI_DTYPE_F32)      \
+            return DEQUANT(BLOCK_SIZE, float);         \
+        else if (_info.dtype == INFINI_DTYPE_BF16)     \
+            return DEQUANT(BLOCK_SIZE, __nv_bfloat16); \
+        else                                           \
+            return INFINI_STATUS_BAD_TENSOR_DTYPE;     \
+    }
+    if (_opaque->internal->maxThreadsPerBlock() == CUDA_BLOCK_SIZE_1024) {
+        DEQUANT_WITH_BLOCK_SIZE(CUDA_BLOCK_SIZE_1024)
+    } else if (_opaque->internal->maxThreadsPerBlock() == CUDA_BLOCK_SIZE_512) {
+        DEQUANT_WITH_BLOCK_SIZE(CUDA_BLOCK_SIZE_512)
+    } else if (_opaque->internal->maxThreadsPerBlock() == CUDA_BLOCK_SIZE_4096) {
+        DEQUANT_WITH_BLOCK_SIZE(CUDA_BLOCK_SIZE_4096)
+    } else {
+        return INFINI_STATUS_DEVICE_ARCHITECTURE_NOT_SUPPORTED;
+    }
+    return INFINI_STATUS_SUCCESS;
+}
+
+} // namespace op::per_token_dequant_fp8::nvidia

--- a/src/infiniop/ops/dequant/per_token_dequant_fp8/nvidia/per_token_dequant_fp8_nvidia.cuh
+++ b/src/infiniop/ops/dequant/per_token_dequant_fp8/nvidia/per_token_dequant_fp8_nvidia.cuh
@@ -1,0 +1,7 @@
+#ifndef __PER_TOKEN_DEQUANT_FP8_NVIDIA_API_H__
+#define __PER_TOKEN_DEQUANT_FP8_NVIDIA_API_H__
+#include "../per_token_dequant_fp8.h"
+
+DESCRIPTOR(nvidia)
+
+#endif // __PER_TOKEN_DEQUANT_FP8_NVIDIA_API_H__

--- a/src/infiniop/ops/dequant/per_token_dequant_fp8/operator.cc
+++ b/src/infiniop/ops/dequant/per_token_dequant_fp8/operator.cc
@@ -1,0 +1,98 @@
+#include "../../../operator.h"
+#include "../../../handle.h"
+#include "infiniop/ops/dequant/per_token_dequant_fp8.h"
+
+#if defined(ENABLE_NVIDIA_API) || defined(ENABLE_QY_API)
+#include "nvidia/per_token_dequant_fp8_nvidia.cuh"
+#endif
+
+__C infiniStatus_t infiniopCreatePerTokenDequantF8Descriptor(infiniopHandle_t handle,
+                                                             infiniopPerTokenDequantF8Descriptor_t *desc_ptr,
+                                                             infiniopTensorDescriptor_t x_desc,
+                                                             infiniopTensorDescriptor_t x_packed_desc,
+                                                             infiniopTensorDescriptor_t x_scale_desc,
+                                                             infiniopTensorDescriptor_t x_zero_desc) {
+#define CREATE(CASE, NAMESPACE)                                                              \
+    case CASE:                                                                               \
+        return op::per_token_dequant_fp8::NAMESPACE::Descriptor::create(                     \
+            handle,                                                                          \
+            reinterpret_cast<op::per_token_dequant_fp8::NAMESPACE::Descriptor **>(desc_ptr), \
+            x_desc,                                                                          \
+            x_packed_desc,                                                                   \
+            x_scale_desc,                                                                    \
+            x_zero_desc);
+    switch (handle->device) {
+#ifdef ENABLE_NVIDIA_API
+        CREATE(INFINI_DEVICE_NVIDIA, nvidia)
+#endif
+#ifdef ENABLE_QY_API
+        CREATE(INFINI_DEVICE_QY, nvidia)
+#endif
+    default:
+        return INFINI_STATUS_DEVICE_TYPE_NOT_SUPPORTED;
+    }
+#undef CREATE
+}
+
+__C infiniStatus_t infiniopGetPerTokenDequantF8WorkspaceSize(infiniopPerTokenDequantF8Descriptor_t desc, size_t *size) {
+    switch (desc->device_type) {
+#define GET(CASE, NAMESPACE)                                                                                    \
+    case CASE:                                                                                                  \
+        *size = reinterpret_cast<op::per_token_dequant_fp8::NAMESPACE::Descriptor *>(desc)->minWorkspaceSize(); \
+        return INFINI_STATUS_SUCCESS;
+#ifdef ENABLE_NVIDIA_API
+        GET(INFINI_DEVICE_NVIDIA, nvidia)
+#endif
+#ifdef ENABLE_QY_API
+        GET(INFINI_DEVICE_QY, nvidia)
+#endif
+    default:
+        return INFINI_STATUS_DEVICE_TYPE_NOT_SUPPORTED;
+    }
+#undef GET
+}
+
+__C infiniStatus_t infiniopPerTokenDequantF8(infiniopPerTokenDequantF8Descriptor_t desc,
+                                             void *workspace,
+                                             size_t workspace_size,
+                                             void *x,
+                                             const void *x_packed,
+                                             const void *x_scale,
+                                             const void *x_zero,
+                                             void *stream) {
+#define DEQUANT(CASE, NAMESPACE)                                                                      \
+    case CASE:                                                                                        \
+        return reinterpret_cast<op::per_token_dequant_fp8::NAMESPACE::Descriptor *>(desc)->calculate( \
+            workspace, workspace_size, x, x_packed, x_scale, x_zero, stream);
+
+    switch (desc->device_type) {
+#ifdef ENABLE_NVIDIA_API
+        DEQUANT(INFINI_DEVICE_NVIDIA, nvidia)
+#endif
+#ifdef ENABLE_QY_API
+        DEQUANT(INFINI_DEVICE_QY, nvidia)
+#endif
+    default:
+        return INFINI_STATUS_DEVICE_TYPE_NOT_SUPPORTED;
+    }
+#undef DEQUANT
+}
+
+__C infiniStatus_t infiniopDestroyPerTokenDequantF8Descriptor(infiniopPerTokenDequantF8Descriptor_t desc) {
+#define DESTROY(CASE, NAMESPACE)                                                           \
+    case CASE:                                                                             \
+        delete reinterpret_cast<op::per_token_dequant_fp8::NAMESPACE::Descriptor *>(desc); \
+        return INFINI_STATUS_SUCCESS;
+
+    switch (desc->device_type) {
+#ifdef ENABLE_NVIDIA_API
+        DESTROY(INFINI_DEVICE_NVIDIA, nvidia)
+#endif
+#ifdef ENABLE_QY_API
+        DESTROY(INFINI_DEVICE_QY, nvidia)
+#endif
+    default:
+        return INFINI_STATUS_DEVICE_TYPE_NOT_SUPPORTED;
+    }
+#undef DESTROY
+}

--- a/src/infiniop/ops/dequant/per_token_dequant_fp8/per_token_dequant_fp8.h
+++ b/src/infiniop/ops/dequant/per_token_dequant_fp8/per_token_dequant_fp8.h
@@ -1,0 +1,40 @@
+#ifndef __PER_TOKEN_DEQUANT_FP8_H__
+#define __PER_TOKEN_DEQUANT_FP8_H__
+
+#include "../../../operator.h"
+#include "info.h"
+
+#define DESCRIPTOR(NAMESPACE)                                                                            \
+                                                                                                         \
+    namespace op::per_token_dequant_fp8::NAMESPACE {                                                     \
+    class Descriptor final : public InfiniopDescriptor {                                                 \
+        struct Opaque;                                                                                   \
+        Opaque *_opaque;                                                                                 \
+        PerTokenDequantF8Info _info;                                                                     \
+        size_t _workspace_size;                                                                          \
+                                                                                                         \
+        Descriptor(Opaque *opaque, PerTokenDequantF8Info info,                                           \
+                   size_t workspace_size,                                                                \
+                   infiniDevice_t device_type, int device_id)                                            \
+            : InfiniopDescriptor{device_type, device_id},                                                \
+              _opaque(opaque), _info(info), _workspace_size(workspace_size) {}                           \
+                                                                                                         \
+    public:                                                                                              \
+        ~Descriptor();                                                                                   \
+                                                                                                         \
+        size_t minWorkspaceSize() const { return _workspace_size; }                                      \
+                                                                                                         \
+        static infiniStatus_t create(                                                                    \
+            infiniopHandle_t handle, Descriptor **desc_ptr,                                              \
+            infiniopTensorDescriptor_t x_desc,                                                           \
+            infiniopTensorDescriptor_t x_packed_desc,                                                    \
+            infiniopTensorDescriptor_t x_scale_desc,                                                     \
+            infiniopTensorDescriptor_t x_zero_desc);                                                     \
+                                                                                                         \
+        infiniStatus_t calculate(                                                                        \
+            void *workspace, size_t workspace_size,                                                      \
+            void *x, const void *x_packed, const void *x_scale, const void *x_zero, void *stream) const; \
+    };                                                                                                   \
+    }
+
+#endif // __PER_TOKEN_DEQUANT_FP8_H__

--- a/src/infiniop/ops/quant/per_tensor_quant_fp8/cuda/kernel.cuh
+++ b/src/infiniop/ops/quant/per_tensor_quant_fp8/cuda/kernel.cuh
@@ -1,0 +1,131 @@
+#ifndef __PER_TENSOR_QUANT_FP8_KERNEL_CUH__
+#define __PER_TENSOR_QUANT_FP8_KERNEL_CUH__
+
+#ifdef ENABLE_NVIDIA_API
+#include <flashinfer/vec_dtypes.cuh>
+#endif
+#include "../../utils.h"
+#include <c10/util/Float8_e4m3fn.h>
+#include <cmath>
+#include <cub/block/block_reduce.cuh>
+
+template <typename T, unsigned int BLOCK_SIZE>
+__device__ void
+per_tensor_absmax_kernel(const T *__restrict__ input, float *__restrict__ output_s, const int64_t num_elements) {
+#ifdef ENABLE_NVIDIA_API
+    float max_value = -__FLT_MAX__;
+    unsigned int tid = threadIdx.x;
+    unsigned int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    const int grid_size = blockDim.x * gridDim.x;
+
+    constexpr uint32_t vec_size = 16 / sizeof(T);
+    using vec_t = flashinfer::vec_t<T, vec_size>;
+
+    const int32_t num_vec_elems = num_elements / vec_size;
+
+    for (int32_t i = gid; i < num_vec_elems; i += grid_size) {
+        vec_t input_vec;
+        input_vec.cast_load(input + i * vec_size);
+
+#pragma unroll
+        for (uint32_t j = 0; j < vec_size; ++j) {
+            float val = static_cast<float>(input_vec[j]);
+            max_value = fmaxf(max_value, fabsf(val));
+        }
+    }
+
+    const int32_t remaining_start = num_vec_elems * vec_size;
+    for (int32_t idx = remaining_start + gid; idx < num_elements; idx += grid_size) {
+        float val = static_cast<float>(input[idx]);
+        max_value = fmaxf(max_value, fabsf(val));
+    }
+
+    max_value = blockReduceMax(max_value);
+
+    if (tid == 0) {
+        atomicMaxFloat(output_s, max_value / FP8_E4M3_MAX);
+    }
+#elif defined ENABLE_QY_API
+    unsigned int tid = threadIdx.x;
+    unsigned int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    const int grid_size = blockDim.x * gridDim.x;
+
+    float thread_max = -__FLT_MAX__;
+    for (int ind = gid; ind < num_elements; ind += grid_size) {
+        thread_max = fmaxf(thread_max, fabsf((float)input[ind]));
+    }
+    float local_max = blockReduceMax(thread_max);
+    if (tid == 0) {
+        atomicMaxFloat(output_s, local_max / FP8_E4M3_MAX);
+    }
+#endif
+}
+
+template <typename T, typename DST_DTYPE>
+__device__ void per_tensor_quant_fp8_kernel(
+    const T *__restrict__ input,
+    DST_DTYPE *__restrict__ output,
+    const float *__restrict__ scale,
+    const int64_t num_elements) {
+#ifdef ENABLE_NVIDIA_API
+    const int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    const int grid_size = blockDim.x * gridDim.x;
+    const float scale_val = 1.0f / (*scale);
+
+    // We want to store 128 bits of data at a time. 16 = 128 / 8 bits
+    // Load is already vectorized, so 16 elements work for T.
+    const uint32_t VEC_SIZE = 16;
+    using vec_t = flashinfer::vec_t<T, VEC_SIZE>;
+
+    const int32_t num_vec_elems = num_elements / VEC_SIZE;
+
+    for (int32_t i = gid; i < num_vec_elems; i += grid_size) {
+        vec_t input_vec;
+        input_vec.cast_load(input + i * VEC_SIZE);
+
+        DST_DTYPE output_arr[VEC_SIZE];
+#pragma unroll
+        for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+            float val = fmax(fmin(static_cast<float>(input_vec[j]) * scale_val, FP8_E4M3_MAX), -FP8_E4M3_MAX);
+#if !defined(USE_ROCM) || defined(HIP_FP8_TYPE_E4M3)
+            output_arr[j] = static_cast<DST_DTYPE>(val);
+#else
+            output_arr[j] = c10::Float8_e4m3fnuz(
+                __hip_cvt_float_to_fp8(val, fp8::fp8_type::__default_saturation, fp8::fp8_type::__default_interpret),
+                c10::Float8_e4m3fnuz::from_bits());
+#endif
+        }
+        *(uint4 *)(output + i * VEC_SIZE) = *(uint4 *)output_arr;
+    }
+
+    const int32_t remaining_start = num_vec_elems * VEC_SIZE;
+    for (int32_t idx = remaining_start + gid; idx < num_elements; idx += grid_size) {
+        float val = fmax(-FP8_E4M3_MAX, fmin(static_cast<float>(input[idx]) * scale_val, FP8_E4M3_MAX));
+#if !defined(USE_ROCM) || defined(HIP_FP8_TYPE_E4M3)
+        output[idx] = static_cast<DST_DTYPE>(val);
+#else
+        output[idx] = c10::Float8_e4m3fnuz(
+            __hip_cvt_float_to_fp8(val, fp8::fp8_type::__default_saturation, fp8::fp8_type::__default_interpret),
+            c10::Float8_e4m3fnuz::from_bits());
+#endif
+    }
+#elif defined ENABLE_QY_API
+    const int gid = threadIdx.x + blockIdx.x * blockDim.x;
+    const int grid_size = blockDim.x * gridDim.x;
+    const float scale_val = 1.0f / scale[0];
+
+    for (int tid = gid; tid < num_elements; tid += grid_size) {
+        float val = fmax(-FP8_E4M3_MAX, fmin(static_cast<float>(input[tid]) * scale_val, FP8_E4M3_MAX));
+#if !defined(USE_ROCM) || defined(HIP_FP8_TYPE_E4M3)
+        output[tid] = static_cast<DST_DTYPE>(val);
+#else
+        output[tid] = c10::Float8_e4m3fnuz(
+            __hip_cvt_float_to_fp8(val, fp8::fp8_type::__default_saturation, fp8::fp8_type::__default_interpret),
+            c10::Float8_e4m3fnuz::from_bits());
+#endif
+    }
+
+#endif
+}
+
+#endif // __PER_TENSOR_QUANT_FP8_KERNEL_CUH__

--- a/src/infiniop/ops/quant/per_tensor_quant_fp8/info.h
+++ b/src/infiniop/ops/quant/per_tensor_quant_fp8/info.h
@@ -20,8 +20,7 @@ public:
         infiniopTensorDescriptor_t x_packed_desc,
         infiniopTensorDescriptor_t x_scale_desc,
         infiniopTensorDescriptor_t x_zero_desc,
-        infiniopTensorDescriptor_t x_desc,
-        bool is_static) {
+        infiniopTensorDescriptor_t x_desc) {
 
         CHECK_OR_RETURN(
             x_packed_desc != nullptr && x_scale_desc != nullptr && x_desc != nullptr,
@@ -47,7 +46,6 @@ public:
             dtype,
             packed_type,
             num_elements,
-            is_static,
         });
     }
 };

--- a/src/infiniop/ops/quant/per_tensor_quant_fp8/info.h
+++ b/src/infiniop/ops/quant/per_tensor_quant_fp8/info.h
@@ -1,0 +1,57 @@
+#ifndef __PER_TENSOR_QUANT_FP8_INFO_H__
+#define __PER_TENSOR_QUANT_FP8_INFO_H__
+
+#include "../../../../utils.h"
+#include "../../../operator.h"
+#include "../../../tensor.h"
+
+namespace op::per_tensor_quant_fp8 {
+
+class PerTensorQuantF8Info {
+private:
+    PerTensorQuantF8Info() = default;
+
+public:
+    infiniDtype_t dtype, packed_type;
+    int64_t num_elements;
+    bool is_static;
+
+    static utils::Result<PerTensorQuantF8Info> createPerTensorQuantF8Info(
+        infiniopTensorDescriptor_t x_packed_desc,
+        infiniopTensorDescriptor_t x_scale_desc,
+        infiniopTensorDescriptor_t x_zero_desc,
+        infiniopTensorDescriptor_t x_desc,
+        bool is_static) {
+
+        CHECK_OR_RETURN(
+            x_packed_desc != nullptr && x_scale_desc != nullptr && x_desc != nullptr,
+            INFINI_STATUS_NULL_POINTER);
+
+        const infiniDtype_t dtype = x_desc->dtype();
+        const infiniDtype_t packed_type = x_packed_desc->dtype();
+
+        CHECK_DTYPE(dtype, INFINI_DTYPE_F16, INFINI_DTYPE_BF16, INFINI_DTYPE_F32);
+        CHECK_DTYPE(packed_type, INFINI_DTYPE_F8);
+
+        auto shape = x_desc->shape();
+        CHECK_SAME_SHAPE(shape, x_packed_desc->shape());
+
+        auto ndim = x_desc->ndim();
+
+        int64_t num_elements = 1;
+        for (int i = 0; i < (int)ndim; i++) {
+            num_elements *= static_cast<int64_t>(shape[i]);
+        }
+
+        return utils::Result<PerTensorQuantF8Info>(PerTensorQuantF8Info{
+            dtype,
+            packed_type,
+            num_elements,
+            is_static,
+        });
+    }
+};
+
+} // namespace op::per_tensor_quant_fp8
+
+#endif //  __PER_TENSOR_QUANT_FP8_INFO_H__

--- a/src/infiniop/ops/quant/per_tensor_quant_fp8/nvidia/per_tensor_quant_fp8_nvidia.cu
+++ b/src/infiniop/ops/quant/per_tensor_quant_fp8/nvidia/per_tensor_quant_fp8_nvidia.cu
@@ -1,0 +1,112 @@
+#include "../../../../devices/nvidia/nvidia_common.cuh"
+#include "per_tensor_quant_fp8_nvidia.cuh"
+
+#include "../../../../devices/nvidia/nvidia_kernel_common.cuh"
+#include "../../../../reduce/cuda/reduce.cuh"
+#include <cub/block/block_reduce.cuh>
+
+#include "../cuda/kernel.cuh"
+
+template <typename Tdata, unsigned int BLOCK_SIZE>
+INFINIOP_CUDA_KERNEL blockPerTensorAbsmaxSym(
+    float *x_scale, const Tdata *x, const int64_t num_elements) {
+    per_tensor_absmax_kernel<Tdata, BLOCK_SIZE>(
+        x, x_scale, num_elements);
+}
+
+template <typename Tdata, typename DST_DTYPE, unsigned int BLOCK_SIZE>
+INFINIOP_CUDA_KERNEL blockPerTensorQuantF8Sym(
+    DST_DTYPE *x_packed, float *x_scale, const Tdata *x, const int64_t num_elements) {
+    per_tensor_quant_fp8_kernel<Tdata, DST_DTYPE>(
+        x,
+        x_packed,
+        x_scale,
+        num_elements);
+}
+
+namespace op::per_tensor_quant_fp8::nvidia {
+
+struct Descriptor::Opaque {
+    std::shared_ptr<device::nvidia::Handle::Internal> internal;
+};
+
+Descriptor::~Descriptor() {
+    delete _opaque;
+}
+
+infiniStatus_t Descriptor::create(
+    infiniopHandle_t handle, Descriptor **desc_ptr,
+    infiniopTensorDescriptor_t x_packed_desc,
+    infiniopTensorDescriptor_t x_scale_desc,
+    infiniopTensorDescriptor_t x_zero_desc,
+    infiniopTensorDescriptor_t x_desc,
+    bool is_static) {
+
+    auto info = PerTensorQuantF8Info::createPerTensorQuantF8Info(x_packed_desc, x_scale_desc, x_zero_desc, x_desc, is_static);
+
+    CHECK_RESULT(info);
+
+    *desc_ptr = new Descriptor(
+        new Opaque{reinterpret_cast<device::nvidia::Handle *>(handle)->internal()},
+        info.take(), 0, handle->device, handle->device_id);
+
+    return INFINI_STATUS_SUCCESS;
+}
+
+template <unsigned int BLOCK_SIZE, typename Tdata>
+infiniStatus_t per_tensor_quant_fp8Kernel(const PerTensorQuantF8Info &info, __nv_fp8_e4m3 *x_packed, float *x_scale, float *x_zero, const Tdata *x, cudaStream_t stream) {
+    const uint64_t num_elements = info.num_elements;
+    bool is_static = info.is_static;
+#ifdef ENABLE_NVIDIA_API
+    constexpr unsigned int block_size = 256;
+#else
+    constexpr unsigned int block_size = BLOCK_SIZE;
+#endif
+    int num_blocks = min((static_cast<int>(num_elements) + block_size - 1) / block_size, 1024);
+
+    dim3 grid(num_blocks);
+    dim3 block(block_size);
+    if (x_zero == nullptr) {
+        if (is_static == false) {
+            blockPerTensorAbsmaxSym<Tdata, block_size>
+                <<<grid, block, 0, stream>>>(x_scale, x, num_elements);
+        }
+        blockPerTensorQuantF8Sym<Tdata, __nv_fp8_e4m3, block_size>
+            <<<grid, block, 0, stream>>>(x_packed, x_scale, x, num_elements);
+    } else {
+        return INFINI_STATUS_BAD_PARAM;
+    }
+
+    return INFINI_STATUS_SUCCESS;
+}
+
+infiniStatus_t Descriptor::calculate(void *workspace, size_t workspace_size,
+                                     void *x_packed, void *x_scale, void *x_zero, const void *x,
+                                     void *stream_) const {
+    cudaStream_t stream = (cudaStream_t)stream_;
+#define QUANT(BLOCK_SIZE, TDATA) \
+    per_tensor_quant_fp8Kernel<BLOCK_SIZE, TDATA>(_info, (__nv_fp8_e4m3 *)x_packed, (float *)x_scale, (float *)x_zero, (const TDATA *)x, stream)
+#define QUANT_WITH_BLOCK_SIZE(BLOCK_SIZE)            \
+    {                                                \
+        if (_info.dtype == INFINI_DTYPE_F16)         \
+            return QUANT(BLOCK_SIZE, half);          \
+        else if (_info.dtype == INFINI_DTYPE_F32)    \
+            return QUANT(BLOCK_SIZE, float);         \
+        else if (_info.dtype == INFINI_DTYPE_BF16)   \
+            return QUANT(BLOCK_SIZE, __nv_bfloat16); \
+        else                                         \
+            return INFINI_STATUS_BAD_TENSOR_DTYPE;   \
+    }
+    if (_opaque->internal->maxThreadsPerBlock() == CUDA_BLOCK_SIZE_1024) {
+        QUANT_WITH_BLOCK_SIZE(CUDA_BLOCK_SIZE_1024)
+    } else if (_opaque->internal->maxThreadsPerBlock() == CUDA_BLOCK_SIZE_512) {
+        QUANT_WITH_BLOCK_SIZE(CUDA_BLOCK_SIZE_512)
+    } else if (_opaque->internal->maxThreadsPerBlock() == CUDA_BLOCK_SIZE_4096) {
+        QUANT_WITH_BLOCK_SIZE(CUDA_BLOCK_SIZE_4096)
+    } else {
+        return INFINI_STATUS_DEVICE_ARCHITECTURE_NOT_SUPPORTED;
+    }
+    return INFINI_STATUS_SUCCESS;
+}
+
+} // namespace op::per_tensor_quant_fp8::nvidia

--- a/src/infiniop/ops/quant/per_tensor_quant_fp8/nvidia/per_tensor_quant_fp8_nvidia.cu
+++ b/src/infiniop/ops/quant/per_tensor_quant_fp8/nvidia/per_tensor_quant_fp8_nvidia.cu
@@ -39,10 +39,9 @@ infiniStatus_t Descriptor::create(
     infiniopTensorDescriptor_t x_packed_desc,
     infiniopTensorDescriptor_t x_scale_desc,
     infiniopTensorDescriptor_t x_zero_desc,
-    infiniopTensorDescriptor_t x_desc,
-    bool is_static) {
+    infiniopTensorDescriptor_t x_desc) {
 
-    auto info = PerTensorQuantF8Info::createPerTensorQuantF8Info(x_packed_desc, x_scale_desc, x_zero_desc, x_desc, is_static);
+    auto info = PerTensorQuantF8Info::createPerTensorQuantF8Info(x_packed_desc, x_scale_desc, x_zero_desc, x_desc);
 
     CHECK_RESULT(info);
 
@@ -54,9 +53,9 @@ infiniStatus_t Descriptor::create(
 }
 
 template <unsigned int BLOCK_SIZE, typename Tdata>
-infiniStatus_t per_tensor_quant_fp8Kernel(const PerTensorQuantF8Info &info, __nv_fp8_e4m3 *x_packed, float *x_scale, float *x_zero, const Tdata *x, cudaStream_t stream) {
+infiniStatus_t per_tensor_quant_fp8Kernel(const PerTensorQuantF8Info &info, __nv_fp8_e4m3 *x_packed, float *x_scale, float *x_zero, const Tdata *x, const bool is_static, cudaStream_t stream) {
     const uint64_t num_elements = info.num_elements;
-    bool is_static = info.is_static;
+
 #ifdef ENABLE_NVIDIA_API
     constexpr unsigned int block_size = 256;
 #else
@@ -81,11 +80,11 @@ infiniStatus_t per_tensor_quant_fp8Kernel(const PerTensorQuantF8Info &info, __nv
 }
 
 infiniStatus_t Descriptor::calculate(void *workspace, size_t workspace_size,
-                                     void *x_packed, void *x_scale, void *x_zero, const void *x,
+                                     void *x_packed, void *x_scale, void *x_zero, const void *x, const bool is_static,
                                      void *stream_) const {
     cudaStream_t stream = (cudaStream_t)stream_;
 #define QUANT(BLOCK_SIZE, TDATA) \
-    per_tensor_quant_fp8Kernel<BLOCK_SIZE, TDATA>(_info, (__nv_fp8_e4m3 *)x_packed, (float *)x_scale, (float *)x_zero, (const TDATA *)x, stream)
+    per_tensor_quant_fp8Kernel<BLOCK_SIZE, TDATA>(_info, (__nv_fp8_e4m3 *)x_packed, (float *)x_scale, (float *)x_zero, (const TDATA *)x, is_static, stream)
 #define QUANT_WITH_BLOCK_SIZE(BLOCK_SIZE)            \
     {                                                \
         if (_info.dtype == INFINI_DTYPE_F16)         \

--- a/src/infiniop/ops/quant/per_tensor_quant_fp8/nvidia/per_tensor_quant_fp8_nvidia.cuh
+++ b/src/infiniop/ops/quant/per_tensor_quant_fp8/nvidia/per_tensor_quant_fp8_nvidia.cuh
@@ -1,0 +1,7 @@
+#ifndef __PER_TENSOR_QUANT_FP8_NVIDIA_API_H__
+#define __PER_TENSOR_QUANT_FP8_NVIDIA_API_H__
+#include "../per_tensor_quant_fp8.h"
+
+DESCRIPTOR(nvidia)
+
+#endif // __PER_TENSOR_QUANT_FP8_NVIDIA_API_H__

--- a/src/infiniop/ops/quant/per_tensor_quant_fp8/operator.cc
+++ b/src/infiniop/ops/quant/per_tensor_quant_fp8/operator.cc
@@ -1,0 +1,100 @@
+#include "../../../operator.h"
+#include "../../../handle.h"
+#include "infiniop/ops/quant/per_tensor_quant_fp8.h"
+
+#if defined(ENABLE_NVIDIA_API) || defined(ENABLE_QY_API)
+#include "nvidia/per_tensor_quant_fp8_nvidia.cuh"
+#endif
+
+__C infiniStatus_t infiniopCreatePerTensorQuantF8Descriptor(infiniopHandle_t handle,
+                                                            infiniopPerTensorQuantF8Descriptor_t *desc_ptr,
+                                                            infiniopTensorDescriptor_t x_packed_desc,
+                                                            infiniopTensorDescriptor_t x_scale_desc,
+                                                            infiniopTensorDescriptor_t x_zero_desc,
+                                                            infiniopTensorDescriptor_t x_desc,
+                                                            bool is_static) {
+#define CREATE(CASE, NAMESPACE)                                                             \
+    case CASE:                                                                              \
+        return op::per_tensor_quant_fp8::NAMESPACE::Descriptor::create(                     \
+            handle,                                                                         \
+            reinterpret_cast<op::per_tensor_quant_fp8::NAMESPACE::Descriptor **>(desc_ptr), \
+            x_packed_desc,                                                                  \
+            x_scale_desc,                                                                   \
+            x_zero_desc,                                                                    \
+            x_desc,                                                                         \
+            is_static);
+    switch (handle->device) {
+#ifdef ENABLE_NVIDIA_API
+        CREATE(INFINI_DEVICE_NVIDIA, nvidia)
+#endif
+#ifdef ENABLE_QY_API
+        CREATE(INFINI_DEVICE_QY, nvidia)
+#endif
+    default:
+        return INFINI_STATUS_DEVICE_TYPE_NOT_SUPPORTED;
+    }
+#undef CREATE
+}
+
+__C infiniStatus_t infiniopGetPerTensorQuantF8WorkspaceSize(infiniopPerTensorQuantF8Descriptor_t desc, size_t *size) {
+    switch (desc->device_type) {
+#define GET(CASE, NAMESPACE)                                                                                   \
+    case CASE:                                                                                                 \
+        *size = reinterpret_cast<op::per_tensor_quant_fp8::NAMESPACE::Descriptor *>(desc)->minWorkspaceSize(); \
+        return INFINI_STATUS_SUCCESS;
+#ifdef ENABLE_NVIDIA_API
+        GET(INFINI_DEVICE_NVIDIA, nvidia)
+#endif
+#ifdef ENABLE_QY_API
+        GET(INFINI_DEVICE_QY, nvidia)
+#endif
+    default:
+        return INFINI_STATUS_DEVICE_TYPE_NOT_SUPPORTED;
+    }
+#undef GET
+}
+
+__C infiniStatus_t infiniopPerTensorQuantF8(infiniopPerTensorQuantF8Descriptor_t desc,
+                                            void *workspace,
+                                            size_t workspace_size,
+                                            void *x_packed,
+                                            void *x_scale,
+                                            void *x_zero,
+                                            const void *x,
+                                            void *stream) {
+#define QUANT(CASE, NAMESPACE)                                                                       \
+    case CASE:                                                                                       \
+        return reinterpret_cast<op::per_tensor_quant_fp8::NAMESPACE::Descriptor *>(desc)->calculate( \
+            workspace, workspace_size, x_packed, x_scale, x_zero, x, stream);
+
+    switch (desc->device_type) {
+#ifdef ENABLE_NVIDIA_API
+        QUANT(INFINI_DEVICE_NVIDIA, nvidia)
+#endif
+#ifdef ENABLE_QY_API
+        QUANT(INFINI_DEVICE_QY, nvidia)
+#endif
+    default:
+        return INFINI_STATUS_DEVICE_TYPE_NOT_SUPPORTED;
+    }
+#undef QUANT
+}
+
+__C infiniStatus_t infiniopDestroyPerTensorQuantF8Descriptor(infiniopPerTensorQuantF8Descriptor_t desc) {
+#define DESTROY(CASE, NAMESPACE)                                                          \
+    case CASE:                                                                            \
+        delete reinterpret_cast<op::per_tensor_quant_fp8::NAMESPACE::Descriptor *>(desc); \
+        return INFINI_STATUS_SUCCESS;
+
+    switch (desc->device_type) {
+#ifdef ENABLE_NVIDIA_API
+        DESTROY(INFINI_DEVICE_NVIDIA, nvidia)
+#endif
+#ifdef ENABLE_QY_API
+        DESTROY(INFINI_DEVICE_QY, nvidia)
+#endif
+    default:
+        return INFINI_STATUS_DEVICE_TYPE_NOT_SUPPORTED;
+    }
+#undef DESTROY
+}

--- a/src/infiniop/ops/quant/per_tensor_quant_fp8/operator.cc
+++ b/src/infiniop/ops/quant/per_tensor_quant_fp8/operator.cc
@@ -11,8 +11,7 @@ __C infiniStatus_t infiniopCreatePerTensorQuantF8Descriptor(infiniopHandle_t han
                                                             infiniopTensorDescriptor_t x_packed_desc,
                                                             infiniopTensorDescriptor_t x_scale_desc,
                                                             infiniopTensorDescriptor_t x_zero_desc,
-                                                            infiniopTensorDescriptor_t x_desc,
-                                                            bool is_static) {
+                                                            infiniopTensorDescriptor_t x_desc) {
 #define CREATE(CASE, NAMESPACE)                                                             \
     case CASE:                                                                              \
         return op::per_tensor_quant_fp8::NAMESPACE::Descriptor::create(                     \
@@ -21,8 +20,7 @@ __C infiniStatus_t infiniopCreatePerTensorQuantF8Descriptor(infiniopHandle_t han
             x_packed_desc,                                                                  \
             x_scale_desc,                                                                   \
             x_zero_desc,                                                                    \
-            x_desc,                                                                         \
-            is_static);
+            x_desc);
     switch (handle->device) {
 #ifdef ENABLE_NVIDIA_API
         CREATE(INFINI_DEVICE_NVIDIA, nvidia)
@@ -61,11 +59,12 @@ __C infiniStatus_t infiniopPerTensorQuantF8(infiniopPerTensorQuantF8Descriptor_t
                                             void *x_scale,
                                             void *x_zero,
                                             const void *x,
+                                            const bool is_static,
                                             void *stream) {
 #define QUANT(CASE, NAMESPACE)                                                                       \
     case CASE:                                                                                       \
         return reinterpret_cast<op::per_tensor_quant_fp8::NAMESPACE::Descriptor *>(desc)->calculate( \
-            workspace, workspace_size, x_packed, x_scale, x_zero, x, stream);
+            workspace, workspace_size, x_packed, x_scale, x_zero, x, is_static, stream);
 
     switch (desc->device_type) {
 #ifdef ENABLE_NVIDIA_API

--- a/src/infiniop/ops/quant/per_tensor_quant_fp8/per_tensor_quant_fp8.h
+++ b/src/infiniop/ops/quant/per_tensor_quant_fp8/per_tensor_quant_fp8.h
@@ -1,0 +1,41 @@
+#ifndef __PER_TENSOR_QUANT_FP8_H__
+#define __PER_TENSOR_QUANT_FP8_H__
+
+#include "../../../operator.h"
+#include "info.h"
+
+#define DESCRIPTOR(NAMESPACE)                                                                \
+                                                                                             \
+    namespace op::per_tensor_quant_fp8::NAMESPACE {                                          \
+    class Descriptor final : public InfiniopDescriptor {                                     \
+        struct Opaque;                                                                       \
+        Opaque *_opaque;                                                                     \
+        PerTensorQuantF8Info _info;                                                          \
+        size_t _workspace_size;                                                              \
+                                                                                             \
+        Descriptor(Opaque *opaque, PerTensorQuantF8Info info,                                \
+                   size_t workspace_size,                                                    \
+                   infiniDevice_t device_type, int device_id)                                \
+            : InfiniopDescriptor{device_type, device_id},                                    \
+              _opaque(opaque), _info(info), _workspace_size(workspace_size) {}               \
+                                                                                             \
+    public:                                                                                  \
+        ~Descriptor();                                                                       \
+                                                                                             \
+        size_t minWorkspaceSize() const { return _workspace_size; }                          \
+                                                                                             \
+        static infiniStatus_t create(                                                        \
+            infiniopHandle_t handle, Descriptor **desc_ptr,                                  \
+            infiniopTensorDescriptor_t x_packed_desc,                                        \
+            infiniopTensorDescriptor_t x_scale_desc,                                         \
+            infiniopTensorDescriptor_t x_zero_desc,                                          \
+            infiniopTensorDescriptor_t x_desc,                                               \
+            bool is_static);                                                                 \
+                                                                                             \
+        infiniStatus_t calculate(                                                            \
+            void *workspace, size_t workspace_size,                                          \
+            void *x_packed, void *x_scale, void *x_zero, const void *x, void *stream) const; \
+    };                                                                                       \
+    }
+
+#endif // __PER_TENSOR_QUANT_FP8_H__

--- a/src/infiniop/ops/quant/per_tensor_quant_fp8/per_tensor_quant_fp8.h
+++ b/src/infiniop/ops/quant/per_tensor_quant_fp8/per_tensor_quant_fp8.h
@@ -4,38 +4,37 @@
 #include "../../../operator.h"
 #include "info.h"
 
-#define DESCRIPTOR(NAMESPACE)                                                                \
-                                                                                             \
-    namespace op::per_tensor_quant_fp8::NAMESPACE {                                          \
-    class Descriptor final : public InfiniopDescriptor {                                     \
-        struct Opaque;                                                                       \
-        Opaque *_opaque;                                                                     \
-        PerTensorQuantF8Info _info;                                                          \
-        size_t _workspace_size;                                                              \
-                                                                                             \
-        Descriptor(Opaque *opaque, PerTensorQuantF8Info info,                                \
-                   size_t workspace_size,                                                    \
-                   infiniDevice_t device_type, int device_id)                                \
-            : InfiniopDescriptor{device_type, device_id},                                    \
-              _opaque(opaque), _info(info), _workspace_size(workspace_size) {}               \
-                                                                                             \
-    public:                                                                                  \
-        ~Descriptor();                                                                       \
-                                                                                             \
-        size_t minWorkspaceSize() const { return _workspace_size; }                          \
-                                                                                             \
-        static infiniStatus_t create(                                                        \
-            infiniopHandle_t handle, Descriptor **desc_ptr,                                  \
-            infiniopTensorDescriptor_t x_packed_desc,                                        \
-            infiniopTensorDescriptor_t x_scale_desc,                                         \
-            infiniopTensorDescriptor_t x_zero_desc,                                          \
-            infiniopTensorDescriptor_t x_desc,                                               \
-            bool is_static);                                                                 \
-                                                                                             \
-        infiniStatus_t calculate(                                                            \
-            void *workspace, size_t workspace_size,                                          \
-            void *x_packed, void *x_scale, void *x_zero, const void *x, void *stream) const; \
-    };                                                                                       \
+#define DESCRIPTOR(NAMESPACE)                                                                                      \
+                                                                                                                   \
+    namespace op::per_tensor_quant_fp8::NAMESPACE {                                                                \
+    class Descriptor final : public InfiniopDescriptor {                                                           \
+        struct Opaque;                                                                                             \
+        Opaque *_opaque;                                                                                           \
+        PerTensorQuantF8Info _info;                                                                                \
+        size_t _workspace_size;                                                                                    \
+                                                                                                                   \
+        Descriptor(Opaque *opaque, PerTensorQuantF8Info info,                                                      \
+                   size_t workspace_size,                                                                          \
+                   infiniDevice_t device_type, int device_id)                                                      \
+            : InfiniopDescriptor{device_type, device_id},                                                          \
+              _opaque(opaque), _info(info), _workspace_size(workspace_size) {}                                     \
+                                                                                                                   \
+    public:                                                                                                        \
+        ~Descriptor();                                                                                             \
+                                                                                                                   \
+        size_t minWorkspaceSize() const { return _workspace_size; }                                                \
+                                                                                                                   \
+        static infiniStatus_t create(                                                                              \
+            infiniopHandle_t handle, Descriptor **desc_ptr,                                                        \
+            infiniopTensorDescriptor_t x_packed_desc,                                                              \
+            infiniopTensorDescriptor_t x_scale_desc,                                                               \
+            infiniopTensorDescriptor_t x_zero_desc,                                                                \
+            infiniopTensorDescriptor_t x_desc);                                                                    \
+                                                                                                                   \
+        infiniStatus_t calculate(                                                                                  \
+            void *workspace, size_t workspace_size,                                                                \
+            void *x_packed, void *x_scale, void *x_zero, const void *x, const bool is_static, void *stream) const; \
+    };                                                                                                             \
     }
 
 #endif // __PER_TENSOR_QUANT_FP8_H__

--- a/src/infiniop/ops/quant/per_token_quant_fp8/cuda/kernel.cuh
+++ b/src/infiniop/ops/quant/per_token_quant_fp8/cuda/kernel.cuh
@@ -1,0 +1,271 @@
+#ifndef __PER_TOKEN_QUANT_FP8_KERNEL_CUH__
+#define __PER_TOKEN_QUANT_FP8_KERNEL_CUH__
+
+#ifdef ENABLE_NVIDIA_API
+#include <flashinfer/vec_dtypes.cuh>
+#endif
+#include "../../utils.h"
+#include <c10/util/Float8_e4m3fn.h>
+#include <cmath>
+#include <cub/block/block_reduce.cuh>
+
+template <typename T>
+struct MaxOp {
+    __device__ __forceinline__ T operator()(const T &a, const T &b) const {
+        return max(a, b);
+    }
+};
+
+template <template <typename> class ReductionOp, typename T,
+          int thread_group_width>
+__inline__ __device__ T WarpAllReduce(T val) {
+    for (int mask = thread_group_width / 2; mask > 0; mask /= 2) {
+        val = ReductionOp<T>()(val, __shfl_xor_sync(0xffffffff, val, mask));
+    }
+    return val;
+}
+
+static constexpr int kWarpSize = 32;
+
+// ---------------------------------------------------------------------------
+// 1. Warp‑local, no shared memory
+//    • One warp handles one token.
+//    • Eight tokens per 256‑thread CTA.
+// ---------------------------------------------------------------------------
+template <typename T, typename DST_DTYPE, unsigned int BLOCK_SIZE, int kTokensPerCTA = 8, int kVecSize = 16>
+__device__ void per_token_quant_fp8_kernel(
+    const T *__restrict__ input,
+    DST_DTYPE *__restrict__ output_q,
+    float *__restrict__ output_s,
+    const int64_t hidden_dim,
+    const int64_t num_tokens) {
+#ifdef ENABLE_NVIDIA_API
+    const int warp_id = threadIdx.x / kWarpSize;       // 0‑7  (8 warps)
+    const int lane_id = threadIdx.x & (kWarpSize - 1); // 0‑31
+    const int token_id = blockIdx.x * kTokensPerCTA + warp_id;
+    if (token_id >= num_tokens) {
+        return;
+    }
+
+    // Global tensors for this token
+    const T *token_input = input + token_id * hidden_dim;
+    DST_DTYPE *token_output = output_q + token_id * hidden_dim;
+    float *token_scale = output_s + token_id;
+
+    //
+    // Pass-1: Perform a warp reduce to find the max_value of a token's hidden_dim
+    //
+    float max_value = 0.f;
+    using vec_t = flashinfer::vec_t<T, kVecSize>;
+    const int32_t num_vec_elems = hidden_dim / kVecSize;
+
+    for (int32_t i = lane_id; i < num_vec_elems; i += kWarpSize) {
+        vec_t input_vec;
+        input_vec.cast_load(token_input + i * kVecSize);
+
+#pragma unroll
+        for (uint32_t j = 0; j < kVecSize; ++j) {
+            max_value = fmaxf(max_value, fabsf(static_cast<float>(input_vec[j])));
+        }
+    }
+
+    float warp_max = warpReduceMax(max_value);
+
+    // NOTE: one CTA has multiple warps (each warp handles one token), so `scale`
+    // must be per-warp/per-thread (register) instead of a single shared variable.
+    const float scale = warp_max / FP8_E4M3_MAX;
+    // Broadcast scale
+    if (lane_id == 0) {
+        token_scale[0] = scale;
+    }
+    const float scale_inv = (scale == 0.f) ? 0.f : 1.0f / scale;
+
+    //
+    // Pass-2: quantize and write back
+    //
+    for (int i = lane_id; i < num_vec_elems; i += kWarpSize) {
+        vec_t input_vec;
+        input_vec.cast_load(token_input + i * kVecSize);
+        DST_DTYPE output_arr[kVecSize];
+#pragma unroll
+        for (uint32_t j = 0; j < kVecSize; ++j) {
+            float val = static_cast<float>(input_vec[j]) * scale_inv;
+            val = fmaxf(fminf(val, FP8_E4M3_MAX), -FP8_E4M3_MAX);
+#if !defined(USE_ROCM) || defined(HIP_FP8_TYPE_E4M3)
+            output_arr[j] = static_cast<DST_DTYPE>(val);
+#else
+            output_arr[j] = c10::Float8_e4m3fnuz(
+                __hip_cvt_float_to_fp8(val, fp8::fp8_type::__default_saturation, fp8::fp8_type::__default_interpret),
+                c10::Float8_e4m3fnuz::from_bits());
+#endif
+        }
+        if constexpr (kVecSize == 16) {
+            *(uint4 *)(token_output + i * kVecSize) = *(uint4 *)output_arr;
+        } else {
+            // Use element-wise copy for vector size 8 to ensure correctness
+            for (int k = 0; k < kVecSize; ++k) {
+                token_output[i * kVecSize + k] = output_arr[k];
+            }
+        }
+    }
+#elif defined ENABLE_QY_API
+    const int warp_id = threadIdx.x / kWarpSize;       // 0‑7  (8 warps)
+    const int lane_id = threadIdx.x & (kWarpSize - 1); // 0‑31
+    const int token_id = blockIdx.x * kTokensPerCTA + warp_id;
+    if (token_id >= num_tokens) {
+        return;
+    }
+    float *token_scale = output_s + token_id;
+    int tid = token_id * hidden_dim;
+    __shared__ float max_total[kTokensPerCTA];
+    float max_data = -__FLT_MAX__;
+
+    // ---- reduce max ----
+    for (int ind = lane_id; ind < hidden_dim; ind += kWarpSize) {
+        float v = fabsf((float)input[tid + ind]);
+        max_data = fmaxf(max_data, v);
+    }
+    float warp_max = warpReduceMax(max_data);
+
+    // NOTE: one CTA has multiple warps (each warp handles one token), so `scale`
+    // must be per-warp/per-thread (register) instead of a single shared variable.
+    const float scale = warp_max / FP8_E4M3_MAX;
+    // Broadcast scale
+    if (lane_id == 0) {
+        token_scale[0] = scale;
+    }
+
+    float scale_inv = (scale == 0.f) ? 0.f : 1.0f / scale;
+    for (int ind = lane_id; ind < hidden_dim; ind += kWarpSize) {
+        float val = fmax(-FP8_E4M3_MAX, fmin(static_cast<float>(input[tid + ind]) * scale_inv, FP8_E4M3_MAX));
+#if !defined(USE_ROCM) || defined(HIP_FP8_TYPE_E4M3)
+        output_q[tid + ind] = static_cast<DST_DTYPE>(val);
+#else
+        output_q[tid + ind] = c10::Float8_e4m3fnuz(
+            __hip_cvt_float_to_fp8(val, fp8::fp8_type::__default_saturation, fp8::fp8_type::__default_interpret),
+            c10::Float8_e4m3fnuz::from_bits());
+#endif
+    }
+
+#endif
+}
+
+// ---------------------------------------------------------------------------
+// 2.  Baseline kernel (1 token / CTA, CUB block reduce)
+// ---------------------------------------------------------------------------
+template <typename T, typename DST_DTYPE, unsigned int BLOCK_SIZE, int kVecSize = 16>
+__device__ void per_token_quant_fp8_small_batch_kernel(
+    const T *__restrict__ input,
+    DST_DTYPE *__restrict__ output_q,
+    float *__restrict__ output_s,
+    const int64_t hidden_dim,
+    const int64_t num_tokens) {
+#ifdef ENABLE_NVIDIA_API
+    const int token_idx = blockIdx.x;
+    if (token_idx >= num_tokens) {
+        return;
+    }
+
+    const int tid = threadIdx.x;
+    const int block_dim = blockDim.x;
+
+    const T *token_input = input + token_idx * hidden_dim;
+    DST_DTYPE *token_output = output_q + token_idx * hidden_dim;
+
+    float max_value = 0.0f;
+
+    // Use template parameter for vector size
+    using vec_t = flashinfer::vec_t<T, kVecSize>;
+    const int32_t num_vec_elems = hidden_dim / kVecSize;
+
+    // Find max using vectorized loads
+    for (int32_t i = tid; i < num_vec_elems; i += block_dim) {
+        vec_t input_vec;
+        input_vec.cast_load(token_input + i * kVecSize);
+
+#pragma unroll
+        for (uint32_t j = 0; j < kVecSize; ++j) {
+            float val = static_cast<float>(input_vec[j]);
+            max_value = fmaxf(max_value, fabsf(val));
+        }
+    }
+
+    max_value = blockReduceMax(max_value);
+
+    __shared__ float scale;
+    if (tid == 0) {
+        scale = max_value / FP8_E4M3_MAX;
+        output_s[token_idx] = scale;
+    }
+    __syncthreads();
+
+    float scale_inv = (scale == 0.f) ? 0.f : 1.0f / scale;
+
+    // Quantize using vectorized loads
+    for (int32_t i = tid; i < num_vec_elems; i += block_dim) {
+        vec_t input_vec;
+        input_vec.cast_load(token_input + i * kVecSize);
+
+        DST_DTYPE output_arr[kVecSize];
+#pragma unroll
+        for (uint32_t j = 0; j < kVecSize; ++j) {
+            float val = fmaxf(fminf(static_cast<float>(input_vec[j]) * scale_inv, FP8_E4M3_MAX), -FP8_E4M3_MAX);
+#if !defined(USE_ROCM) || defined(HIP_FP8_TYPE_E4M3)
+            output_arr[j] = static_cast<DST_DTYPE>(val);
+#else
+            output_arr[j] = c10::Float8_e4m3fnuz(
+                __hip_cvt_float_to_fp8(val, fp8::fp8_type::__default_saturation, fp8::fp8_type::__default_interpret),
+                c10::Float8_e4m3fnuz::from_bits());
+#endif
+        }
+
+        if constexpr (kVecSize == 16) {
+            *(uint4 *)(token_output + i * kVecSize) = *(uint4 *)output_arr;
+        } else {
+            // Use element-wise copy for vector size 8 to ensure correctness
+            for (int k = 0; k < kVecSize; ++k) {
+                token_output[i * kVecSize + k] = output_arr[k];
+            }
+        }
+    }
+#elif defined ENABLE_QY_API
+    const int token_idx = blockIdx.x;
+    if (token_idx >= num_tokens) {
+        return;
+    }
+    int tid = token_idx * hidden_dim;
+    typedef cub::BlockReduce<float, BLOCK_SIZE> BlockReduce;
+    __shared__ typename BlockReduce::TempStorage temp_storage;
+
+    // ---- 2. reduce min ----
+    float thread_max = -__FLT_MAX__;
+    for (int ind = threadIdx.x; ind < hidden_dim; ind += BLOCK_SIZE) {
+        thread_max = fmaxf(thread_max, fabsf((float)input[tid + ind]));
+    }
+    float local_max = BlockReduce(temp_storage).Reduce(thread_max, cub::Max());
+
+    __shared__ float scale;
+    if (threadIdx.x == 0) {
+        scale = local_max / FP8_E4M3_MAX;
+        output_s[token_idx] = scale;
+    }
+    __syncthreads();
+
+    float scale_inv = (scale == 0.f) ? 0.f : 1.0f / scale;
+
+    for (int ind = threadIdx.x; ind < hidden_dim; ind += BLOCK_SIZE) {
+        float val = fmax(-FP8_E4M3_MAX, fmin(static_cast<float>(input[tid + ind]) * scale_inv, FP8_E4M3_MAX));
+#if !defined(USE_ROCM) || defined(HIP_FP8_TYPE_E4M3)
+        output_q[tid + ind] = static_cast<DST_DTYPE>(val);
+#else
+        output_q[tid + ind] = c10::Float8_e4m3fnuz(
+            __hip_cvt_float_to_fp8(val, fp8::fp8_type::__default_saturation, fp8::fp8_type::__default_interpret),
+            c10::Float8_e4m3fnuz::from_bits());
+
+#endif
+    }
+
+#endif
+}
+
+#endif // __PER_TOKEN_QUANT_FP8_KERNEL_CUH__

--- a/src/infiniop/ops/quant/per_token_quant_fp8/info.h
+++ b/src/infiniop/ops/quant/per_token_quant_fp8/info.h
@@ -1,0 +1,60 @@
+#ifndef __PER_TOKEN_QUANT_FP8_INFO_H__
+#define __PER_TOKEN_QUANT_FP8_INFO_H__
+
+#include "../../../../utils.h"
+#include "../../../operator.h"
+#include "../../../tensor.h"
+
+namespace op::per_token_quant_fp8 {
+
+class PerTokenQuantF8Info {
+private:
+    PerTokenQuantF8Info() = default;
+
+public:
+    infiniDtype_t dtype, packed_type;
+    int64_t hidden_dim, num_tokens;
+
+    static utils::Result<PerTokenQuantF8Info> createPerTokenQuantF8Info(
+        infiniopTensorDescriptor_t x_packed_desc,
+        infiniopTensorDescriptor_t x_scale_desc,
+        infiniopTensorDescriptor_t x_zero_desc,
+        infiniopTensorDescriptor_t x_desc) {
+
+        CHECK_OR_RETURN(
+            x_packed_desc != nullptr && x_scale_desc != nullptr && x_desc != nullptr,
+            INFINI_STATUS_NULL_POINTER);
+
+        const infiniDtype_t dtype = x_desc->dtype();
+        const infiniDtype_t packed_type = x_packed_desc->dtype();
+
+        CHECK_DTYPE(dtype, INFINI_DTYPE_F16, INFINI_DTYPE_BF16, INFINI_DTYPE_F32);
+        CHECK_DTYPE(packed_type, INFINI_DTYPE_F8);
+
+        auto shape = x_desc->shape();
+        CHECK_SAME_SHAPE(shape, x_packed_desc->shape());
+        CHECK_OR_RETURN(x_desc->ndim() == 2
+                            && x_packed_desc->ndim() == 2,
+                        INFINI_STATUS_BAD_TENSOR_SHAPE);
+        auto ndim = x_desc->ndim();
+
+        int64_t num_tokens = static_cast<int64_t>(shape[0]);
+        int64_t hidden_dim = static_cast<int64_t>(shape[1]);
+
+        if (hidden_dim % 4 != 0) {
+            throw std::runtime_error(
+                "Hidden dimension must be divisible by 4, got " + std::to_string(hidden_dim));
+        }
+
+        return utils::Result<PerTokenQuantF8Info>(PerTokenQuantF8Info{
+            dtype,
+            packed_type,
+            hidden_dim,
+            num_tokens,
+        });
+    }
+};
+
+} // namespace op::per_token_quant_fp8
+
+#endif //  __PER_TOKEN_QUANT_FP8_INFO_H__

--- a/src/infiniop/ops/quant/per_token_quant_fp8/nvidia/per_token_quant_fp8_nvidia.cu
+++ b/src/infiniop/ops/quant/per_token_quant_fp8/nvidia/per_token_quant_fp8_nvidia.cu
@@ -1,0 +1,184 @@
+#include "../../../../devices/nvidia/nvidia_common.cuh"
+#include "per_token_quant_fp8_nvidia.cuh"
+
+#include "../../../../devices/nvidia/nvidia_kernel_common.cuh"
+#include "../../../../reduce/cuda/reduce.cuh"
+#include <cub/block/block_reduce.cuh>
+
+#include "../cuda/kernel.cuh"
+
+template <typename Tdata, typename DST_DTYPE, unsigned int BLOCK_SIZE, int kTokensPerCTA = 8, int kVecSize = 16>
+INFINIOP_CUDA_KERNEL warpPerTokenQuantF8Sym(
+    DST_DTYPE *x_packed, float *x_scale, const Tdata *x, const int64_t hidden_dim, const int64_t num_tokens) {
+    per_token_quant_fp8_kernel<Tdata, DST_DTYPE, BLOCK_SIZE, kTokensPerCTA, kVecSize>(
+        x, x_packed, x_scale, hidden_dim, num_tokens);
+}
+
+template <typename Tdata, typename DST_DTYPE, unsigned int BLOCK_SIZE, int kVecSize = 16>
+INFINIOP_CUDA_KERNEL blockPerTokenQuantF8Sym(
+    DST_DTYPE *x_packed, float *x_scale, const Tdata *x, const int64_t hidden_dim, const int64_t num_tokens) {
+    per_token_quant_fp8_small_batch_kernel<Tdata, DST_DTYPE, BLOCK_SIZE, kVecSize>(
+        x, x_packed, x_scale, hidden_dim, num_tokens);
+}
+
+#ifdef ENABLE_NVIDIA_API
+inline int getSMCount() {
+    int device = -1;
+    cudaGetDevice(&device);
+
+    int sm_count = 0;
+    cudaDeviceGetAttribute(
+        &sm_count,
+        cudaDevAttrMultiProcessorCount,
+        device);
+
+    return sm_count;
+}
+
+#endif
+
+namespace op::per_token_quant_fp8::nvidia {
+
+struct Descriptor::Opaque {
+    std::shared_ptr<device::nvidia::Handle::Internal> internal;
+};
+
+Descriptor::~Descriptor() {
+    delete _opaque;
+}
+
+infiniStatus_t Descriptor::create(
+    infiniopHandle_t handle, Descriptor **desc_ptr,
+    infiniopTensorDescriptor_t x_packed_desc,
+    infiniopTensorDescriptor_t x_scale_desc,
+    infiniopTensorDescriptor_t x_zero_desc,
+    infiniopTensorDescriptor_t x_desc) {
+
+    auto info = PerTokenQuantF8Info::createPerTokenQuantF8Info(x_packed_desc, x_scale_desc, x_zero_desc, x_desc);
+
+    CHECK_RESULT(info);
+
+    *desc_ptr = new Descriptor(
+        new Opaque{reinterpret_cast<device::nvidia::Handle *>(handle)->internal()},
+        info.take(), 0, handle->device, handle->device_id);
+
+    return INFINI_STATUS_SUCCESS;
+}
+
+template <unsigned int BLOCK_SIZE, typename Tdata>
+infiniStatus_t per_token_quant_fp8Kernel(const PerTokenQuantF8Info &info, __nv_fp8_e4m3 *x_packed, float *x_scale, float *x_zero, const Tdata *x, cudaStream_t stream) {
+
+    const int64_t hidden_dim = info.hidden_dim;
+    const int64_t num_tokens = info.num_tokens;
+
+    const int TOKENS_PER_CTA = 8;
+#ifdef ENABLE_NVIDIA_API
+    int sm_count = getSMCount();
+    const bool use_warp_kernel = (num_tokens >= sm_count * 2 * TOKENS_PER_CTA);
+#else
+    const bool use_warp_kernel = (hidden_dim < 1024);
+#endif
+
+    const bool use_vec16 = (hidden_dim % 16 == 0);
+    const bool use_vec8 = (hidden_dim % 8 == 0);
+
+    if (x_zero == nullptr) {
+        if (use_warp_kernel) {
+
+            // -------- warp‑local ---------------------------------------------------
+            constexpr int THREADS = TOKENS_PER_CTA * kWarpSize; // 256
+            dim3 grid((num_tokens + TOKENS_PER_CTA - 1) / TOKENS_PER_CTA);
+            dim3 block(THREADS);
+
+            if (use_vec16) {
+                warpPerTokenQuantF8Sym<Tdata, __nv_fp8_e4m3, THREADS, TOKENS_PER_CTA, 16><<<grid, block, 0, stream>>>(
+                    x_packed,
+                    x_scale,
+                    x,
+                    hidden_dim,
+                    num_tokens);
+            } else if (use_vec8) {
+                warpPerTokenQuantF8Sym<Tdata, __nv_fp8_e4m3, THREADS, TOKENS_PER_CTA, 8><<<grid, block, 0, stream>>>(
+                    x_packed,
+                    x_scale,
+                    x,
+                    hidden_dim,
+                    num_tokens);
+            } else {
+                warpPerTokenQuantF8Sym<Tdata, __nv_fp8_e4m3, THREADS, TOKENS_PER_CTA, 4><<<grid, block, 0, stream>>>(
+                    x_packed,
+                    x_scale,
+                    x,
+                    hidden_dim,
+                    num_tokens);
+            }
+        } else {
+            // -------- baseline -----------------------------------------------------
+#ifdef ENABLE_NVIDIA_API
+            constexpr unsigned int THREADS = 256;
+#else
+            constexpr unsigned int THREADS = BLOCK_SIZE;
+#endif
+            dim3 grid(num_tokens);
+            dim3 block(THREADS);
+
+            if (use_vec16) {
+                blockPerTokenQuantF8Sym<Tdata, __nv_fp8_e4m3, THREADS, 16><<<grid, block, 0, stream>>>(
+                    x_packed,
+                    x_scale,
+                    x,
+                    hidden_dim,
+                    num_tokens);
+            } else if (use_vec8) {
+                blockPerTokenQuantF8Sym<Tdata, __nv_fp8_e4m3, THREADS, 8><<<grid, block, 0, stream>>>(
+                    x_packed,
+                    x_scale,
+                    x,
+                    hidden_dim,
+                    num_tokens);
+            } else {
+                blockPerTokenQuantF8Sym<Tdata, __nv_fp8_e4m3, THREADS, 4><<<grid, block, 0, stream>>>(
+                    x_packed,
+                    x_scale,
+                    x,
+                    hidden_dim,
+                    num_tokens);
+            }
+        }
+    } else {
+        return INFINI_STATUS_BAD_PARAM;
+    }
+
+    return INFINI_STATUS_SUCCESS;
+}
+
+infiniStatus_t Descriptor::calculate(void *workspace, size_t workspace_size,
+                                     void *x_packed, void *x_scale, void *x_zero, const void *x,
+                                     void *stream_) const {
+    cudaStream_t stream = (cudaStream_t)stream_;
+#define QUANT(BLOCK_SIZE, TDATA) \
+    per_token_quant_fp8Kernel<BLOCK_SIZE, TDATA>(_info, (__nv_fp8_e4m3 *)x_packed, (float *)x_scale, (float *)x_zero, (const TDATA *)x, stream)
+#define QUANT_WITH_BLOCK_SIZE(BLOCK_SIZE)            \
+    {                                                \
+        if (_info.dtype == INFINI_DTYPE_F16)         \
+            return QUANT(BLOCK_SIZE, half);          \
+        else if (_info.dtype == INFINI_DTYPE_F32)    \
+            return QUANT(BLOCK_SIZE, float);         \
+        else if (_info.dtype == INFINI_DTYPE_BF16)   \
+            return QUANT(BLOCK_SIZE, __nv_bfloat16); \
+        else                                         \
+            return INFINI_STATUS_BAD_TENSOR_DTYPE;   \
+    }
+    if (_opaque->internal->maxThreadsPerBlock() == CUDA_BLOCK_SIZE_1024) {
+        QUANT_WITH_BLOCK_SIZE(CUDA_BLOCK_SIZE_1024)
+    } else if (_opaque->internal->maxThreadsPerBlock() == CUDA_BLOCK_SIZE_512) {
+        QUANT_WITH_BLOCK_SIZE(CUDA_BLOCK_SIZE_512)
+    } else if (_opaque->internal->maxThreadsPerBlock() == CUDA_BLOCK_SIZE_4096) {
+        QUANT_WITH_BLOCK_SIZE(CUDA_BLOCK_SIZE_4096)
+    } else {
+        return INFINI_STATUS_DEVICE_ARCHITECTURE_NOT_SUPPORTED;
+    }
+    return INFINI_STATUS_SUCCESS;
+}
+
+} // namespace op::per_token_quant_fp8::nvidia

--- a/src/infiniop/ops/quant/per_token_quant_fp8/nvidia/per_token_quant_fp8_nvidia.cuh
+++ b/src/infiniop/ops/quant/per_token_quant_fp8/nvidia/per_token_quant_fp8_nvidia.cuh
@@ -1,0 +1,7 @@
+#ifndef __PER_TOKEN_QUANT_FP8_NVIDIA_API_H__
+#define __PER_TOKEN_QUANT_FP8_NVIDIA_API_H__
+#include "../per_token_quant_fp8.h"
+
+DESCRIPTOR(nvidia)
+
+#endif // __PER_TOKEN_QUANT_FP8_NVIDIA_API_H__

--- a/src/infiniop/ops/quant/per_token_quant_fp8/operator.cc
+++ b/src/infiniop/ops/quant/per_token_quant_fp8/operator.cc
@@ -1,0 +1,98 @@
+#include "../../../operator.h"
+#include "../../../handle.h"
+#include "infiniop/ops/quant/per_token_quant_fp8.h"
+
+#if defined(ENABLE_NVIDIA_API) || defined(ENABLE_QY_API)
+#include "nvidia/per_token_quant_fp8_nvidia.cuh"
+#endif
+
+__C infiniStatus_t infiniopCreatePerTokenQuantF8Descriptor(infiniopHandle_t handle,
+                                                           infiniopPerTokenQuantF8Descriptor_t *desc_ptr,
+                                                           infiniopTensorDescriptor_t x_packed_desc,
+                                                           infiniopTensorDescriptor_t x_scale_desc,
+                                                           infiniopTensorDescriptor_t x_zero_desc,
+                                                           infiniopTensorDescriptor_t x_desc) {
+#define CREATE(CASE, NAMESPACE)                                                            \
+    case CASE:                                                                             \
+        return op::per_token_quant_fp8::NAMESPACE::Descriptor::create(                     \
+            handle,                                                                        \
+            reinterpret_cast<op::per_token_quant_fp8::NAMESPACE::Descriptor **>(desc_ptr), \
+            x_packed_desc,                                                                 \
+            x_scale_desc,                                                                  \
+            x_zero_desc,                                                                   \
+            x_desc);
+    switch (handle->device) {
+#ifdef ENABLE_NVIDIA_API
+        CREATE(INFINI_DEVICE_NVIDIA, nvidia)
+#endif
+#ifdef ENABLE_QY_API
+        CREATE(INFINI_DEVICE_QY, nvidia)
+#endif
+    default:
+        return INFINI_STATUS_DEVICE_TYPE_NOT_SUPPORTED;
+    }
+#undef CREATE
+}
+
+__C infiniStatus_t infiniopGetPerTokenQuantF8WorkspaceSize(infiniopPerTokenQuantF8Descriptor_t desc, size_t *size) {
+    switch (desc->device_type) {
+#define GET(CASE, NAMESPACE)                                                                                  \
+    case CASE:                                                                                                \
+        *size = reinterpret_cast<op::per_token_quant_fp8::NAMESPACE::Descriptor *>(desc)->minWorkspaceSize(); \
+        return INFINI_STATUS_SUCCESS;
+#ifdef ENABLE_NVIDIA_API
+        GET(INFINI_DEVICE_NVIDIA, nvidia)
+#endif
+#ifdef ENABLE_QY_API
+        GET(INFINI_DEVICE_QY, nvidia)
+#endif
+    default:
+        return INFINI_STATUS_DEVICE_TYPE_NOT_SUPPORTED;
+    }
+#undef GET
+}
+
+__C infiniStatus_t infiniopPerTokenQuantF8(infiniopPerTokenQuantF8Descriptor_t desc,
+                                           void *workspace,
+                                           size_t workspace_size,
+                                           void *x_packed,
+                                           void *x_scale,
+                                           void *x_zero,
+                                           const void *x,
+                                           void *stream) {
+#define QUANT(CASE, NAMESPACE)                                                                      \
+    case CASE:                                                                                      \
+        return reinterpret_cast<op::per_token_quant_fp8::NAMESPACE::Descriptor *>(desc)->calculate( \
+            workspace, workspace_size, x_packed, x_scale, x_zero, x, stream);
+
+    switch (desc->device_type) {
+#ifdef ENABLE_NVIDIA_API
+        QUANT(INFINI_DEVICE_NVIDIA, nvidia)
+#endif
+#ifdef ENABLE_QY_API
+        QUANT(INFINI_DEVICE_QY, nvidia)
+#endif
+    default:
+        return INFINI_STATUS_DEVICE_TYPE_NOT_SUPPORTED;
+    }
+#undef QUANT
+}
+
+__C infiniStatus_t infiniopDestroyPerTokenQuantF8Descriptor(infiniopPerTokenQuantF8Descriptor_t desc) {
+#define DESTROY(CASE, NAMESPACE)                                                         \
+    case CASE:                                                                           \
+        delete reinterpret_cast<op::per_token_quant_fp8::NAMESPACE::Descriptor *>(desc); \
+        return INFINI_STATUS_SUCCESS;
+
+    switch (desc->device_type) {
+#ifdef ENABLE_NVIDIA_API
+        DESTROY(INFINI_DEVICE_NVIDIA, nvidia)
+#endif
+#ifdef ENABLE_QY_API
+        DESTROY(INFINI_DEVICE_QY, nvidia)
+#endif
+    default:
+        return INFINI_STATUS_DEVICE_TYPE_NOT_SUPPORTED;
+    }
+#undef DESTROY
+}

--- a/src/infiniop/ops/quant/per_token_quant_fp8/per_token_quant_fp8.h
+++ b/src/infiniop/ops/quant/per_token_quant_fp8/per_token_quant_fp8.h
@@ -1,0 +1,40 @@
+#ifndef __PER_TOKEN_QUANT_FP8_H__
+#define __PER_TOKEN_QUANT_FP8_H__
+
+#include "../../../operator.h"
+#include "info.h"
+
+#define DESCRIPTOR(NAMESPACE)                                                                \
+                                                                                             \
+    namespace op::per_token_quant_fp8::NAMESPACE {                                           \
+    class Descriptor final : public InfiniopDescriptor {                                     \
+        struct Opaque;                                                                       \
+        Opaque *_opaque;                                                                     \
+        PerTokenQuantF8Info _info;                                                           \
+        size_t _workspace_size;                                                              \
+                                                                                             \
+        Descriptor(Opaque *opaque, PerTokenQuantF8Info info,                                 \
+                   size_t workspace_size,                                                    \
+                   infiniDevice_t device_type, int device_id)                                \
+            : InfiniopDescriptor{device_type, device_id},                                    \
+              _opaque(opaque), _info(info), _workspace_size(workspace_size) {}               \
+                                                                                             \
+    public:                                                                                  \
+        ~Descriptor();                                                                       \
+                                                                                             \
+        size_t minWorkspaceSize() const { return _workspace_size; }                          \
+                                                                                             \
+        static infiniStatus_t create(                                                        \
+            infiniopHandle_t handle, Descriptor **desc_ptr,                                  \
+            infiniopTensorDescriptor_t x_packed_desc,                                        \
+            infiniopTensorDescriptor_t x_scale_desc,                                         \
+            infiniopTensorDescriptor_t x_zero_desc,                                          \
+            infiniopTensorDescriptor_t x_desc);                                              \
+                                                                                             \
+        infiniStatus_t calculate(                                                            \
+            void *workspace, size_t workspace_size,                                          \
+            void *x_packed, void *x_scale, void *x_zero, const void *x, void *stream) const; \
+    };                                                                                       \
+    }
+
+#endif // __PER_TOKEN_QUANT_FP8_H__

--- a/src/infiniop/ops/quant/utils.h
+++ b/src/infiniop/ops/quant/utils.h
@@ -1,0 +1,476 @@
+/* Copyright 2025 SGLang Team. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <ATen/Tensor.h>
+#include <cuda_runtime.h>
+#include <torch/all.h>
+
+#ifdef USE_ROCM
+#include <hip/hip_runtime.h>
+#endif
+
+#ifdef USE_ROCM
+// Adapted from flashinfer-rocm [PR#491](https://github.com/flashinfer-ai/flashinfer/pull/491)
+#define _DISPATCH_CASE_F16(c_type, ...) \
+    case at::ScalarType::Half: {        \
+        using c_type = __half;          \
+        return __VA_ARGS__();           \
+    }
+
+#define _DISPATCH_CASE_BF16(c_type, ...) \
+    case at::ScalarType::BFloat16: {     \
+        using c_type = __hip_bfloat16;   \
+        return __VA_ARGS__();            \
+    }
+#endif // USE_ROCM
+
+#ifndef USE_ROCM
+// Adapt from FlashInfer
+#ifdef FLASHINFER_ENABLE_F16
+#define _DISPATCH_CASE_F16(c_type, ...) \
+    case at::ScalarType::Half: {        \
+        using c_type = nv_half;         \
+        return __VA_ARGS__();           \
+    }
+#else
+#define _DISPATCH_CASE_F16(c_type, ...)
+#endif // FLASHINFER_ENABLE_F16
+
+#ifdef FLASHINFER_ENABLE_BF16
+#define _DISPATCH_CASE_BF16(c_type, ...) \
+    case at::ScalarType::BFloat16: {     \
+        using c_type = nv_bfloat16;      \
+        return __VA_ARGS__();            \
+    }
+#else
+#define _DISPATCH_CASE_BF16(c_type, ...)
+#endif // FLASHINFER_ENABLE_BF16
+
+#ifdef FLASHINFER_ENABLE_FP8_E4M3
+#define _DISPATCH_CASE_FP8_E4M3(c_type, ...) \
+    case at::ScalarType::Float8_e4m3fn: {    \
+        using c_type = __nv_fp8_e4m3;        \
+        return __VA_ARGS__();                \
+    }
+#else
+#define _DISPATCH_CASE_FP8_E4M3(c_type, ...)
+#endif // FLASHINFER_ENABLE_FP8_E4M3
+
+#ifdef FLASHINFER_ENABLE_FP8_E5M2
+#define _DISPATCH_CASE_FP8_E5M2(c_type, ...) \
+    case at::ScalarType::Float8_e5m2: {      \
+        using c_type = __nv_fp8_e5m2;        \
+        return __VA_ARGS__();                \
+    }
+#else
+#define _DISPATCH_CASE_FP8_E5M2(c_type, ...)
+#endif // FLASHINFER_ENABLE_FP8_E5M2
+
+#define DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP16(pytorch_dtype, c_type, ...)                     \
+    [&]() -> bool {                                                                          \
+        switch (pytorch_dtype) {                                                             \
+            _DISPATCH_CASE_F16(c_type, __VA_ARGS__)                                          \
+            _DISPATCH_CASE_BF16(c_type, __VA_ARGS__)                                         \
+        default:                                                                             \
+            std::ostringstream oss;                                                          \
+            oss << __PRETTY_FUNCTION__ << " failed to dispatch data type " << pytorch_dtype; \
+            TORCH_CHECK(false, oss.str());                                                   \
+            return false;                                                                    \
+        }                                                                                    \
+    }()
+
+#define DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP8(pytorch_dtype, c_type, ...)                          \
+    [&]() -> bool {                                                                              \
+        switch (pytorch_dtype) {                                                                 \
+            _DISPATCH_CASE_FP8_E4M3(c_type, __VA_ARGS__)                                         \
+            _DISPATCH_CASE_FP8_E5M2(c_type, __VA_ARGS__)                                         \
+        default:                                                                                 \
+            std::ostringstream oss;                                                              \
+            oss << __PRETTY_FUNCTION__ << " failed to dispatch fp8 data type " << pytorch_dtype; \
+            TORCH_CHECK(false, oss.str());                                                       \
+            return false;                                                                        \
+        }                                                                                        \
+    }()
+
+#define DISPATCH_PYTORCH_DTYPE_TO_CTYPE(pytorch_dtype, c_type, ...)                          \
+    [&]() -> bool {                                                                          \
+        switch (pytorch_dtype) {                                                             \
+            _DISPATCH_CASE_F16(c_type, __VA_ARGS__)                                          \
+            _DISPATCH_CASE_BF16(c_type, __VA_ARGS__)                                         \
+            _DISPATCH_CASE_FP8_E4M3(c_type, __VA_ARGS__)                                     \
+            _DISPATCH_CASE_FP8_E5M2(c_type, __VA_ARGS__)                                     \
+        default:                                                                             \
+            std::ostringstream oss;                                                          \
+            oss << __PRETTY_FUNCTION__ << " failed to dispatch data type " << pytorch_dtype; \
+            TORCH_CHECK(false, oss.str());                                                   \
+            return false;                                                                    \
+        }                                                                                    \
+    }()
+
+#define _DISPATCH_SWITCH(var_name, cond, ...)                                               \
+    [&]() -> bool {                                                                         \
+        switch (cond) {                                                                     \
+            __VA_ARGS__                                                                     \
+        default:                                                                            \
+            std::ostringstream oss;                                                         \
+            oss << __PRETTY_FUNCTION__ << " failed to dispatch " var_name " " << int(cond); \
+            TORCH_CHECK(false, oss.str());                                                  \
+            return false;                                                                   \
+        }                                                                                   \
+    }()
+
+#define _DISPATCH_SWITCH_U16x2(var1_name, var2_name, cond1, cond2, ...)                                                 \
+    [&]() -> bool {                                                                                                     \
+        switch (pack_u16(cond1, cond2)) {                                                                               \
+            __VA_ARGS__                                                                                                 \
+        default:                                                                                                        \
+            std::ostringstream oss;                                                                                     \
+            oss << __PRETTY_FUNCTION__ << " failed to dispatch (" var1_name ", " var2_name "): (" << int(cond1) << ", " \
+                << int(cond2) << ")";                                                                                   \
+            TORCH_CHECK(false, oss.str());                                                                              \
+            return false;                                                                                               \
+        }                                                                                                               \
+    }()
+
+#define _DISPATCH_CASE(case_expr, case_var, ...) \
+    case case_expr: {                            \
+        constexpr auto case_var = case_expr;     \
+        return __VA_ARGS__();                    \
+    }
+
+#define _DISPATCH_CASE_U16x2(case_expr1, case_expr2, case_var1, case_var2, ...) \
+    case pack_u16(case_expr1, case_expr2): {                                    \
+        constexpr auto case_var1 = case_expr1;                                  \
+        constexpr auto case_var2 = case_expr2;                                  \
+        return __VA_ARGS__();                                                   \
+    }
+
+#define DISPATCH_BOOL(expr, const_expr, ...)   \
+    [&]() -> bool {                            \
+        if (expr) {                            \
+            constexpr bool const_expr = true;  \
+            return __VA_ARGS__();              \
+        } else {                               \
+            constexpr bool const_expr = false; \
+            return __VA_ARGS__();              \
+        }                                      \
+    }()
+
+inline void check_shape(const at::Tensor &a, const at::Tensor &b, const char *a_name, const char *b_name) {
+    TORCH_CHECK(a.dim() == b.dim(), a_name, ".dim() != ", b_name, ".dim(). ", a.dim(), " vs ", b.dim());
+    for (int i = 0; i < a.dim(); ++i) {
+        TORCH_CHECK(a.size(i) == b.size(i), a_name, ".size(", i, ") != ", b_name, ".size(", i, ")");
+    }
+}
+
+inline constexpr uint32_t pack_u16(uint16_t a, uint16_t b) {
+    return (uint32_t(a) << 16) | uint32_t(b);
+}
+
+#define CHECK_GQA_HEAD_DIVISIBLE(num_qo_heads, num_kv_heads) \
+    TORCH_CHECK(                                             \
+        num_qo_heads % num_kv_heads == 0,                    \
+        "num_qo_heads(",                                     \
+        num_qo_heads,                                        \
+        ") must be divisible by num_kv_heads(",              \
+        num_kv_heads,                                        \
+        ")")
+
+// #define CHECK_CUDA(x) TORCH_CHECK(x.is_cuda(), #x " must be a CUDA tensor")
+
+#define CHECK_CONTIGUOUS(x) TORCH_CHECK(x.is_contiguous(), #x " must be contiguous")
+#define CHECK_LAST_DIM_CONTIGUOUS(x) \
+    TORCH_CHECK(x.strides()[x.strides().size() - 1] == 1, #x "must be contiguous at last dimension")
+
+#define CHECK_INPUT(x) \
+    CHECK_CUDA(x);     \
+    CHECK_CONTIGUOUS(x)
+#define CHECK_LAST_DIM_CONTIGUOUS_INPUT(x) \
+    CHECK_CUDA(x);                         \
+    CHECK_LAST_DIM_CONTIGUOUS(x)
+
+#define CHECK_DIM(d, x) TORCH_CHECK(x.dim() == d, #x " must be a " #d "D tensor")
+
+#define CHECK_SHAPE(a, b) check_shape(a, b, #a, #b)
+
+#define CHECK_EQ(a, b) TORCH_CHECK((a) == (b), "CHECK_EQ(" #a ", " #b ") failed. ", a, " vs ", b)
+
+#define CHECK_GE(a, b) TORCH_CHECK((a) >= (b), "CHECK_GE(" #a ", " #b ") failed. ", a, " vs ", b)
+
+inline bool is_float8_tensor(const at::Tensor &tensor) {
+    return tensor.scalar_type() == at::ScalarType::Float8_e4m3fn || tensor.scalar_type() == at::ScalarType::Float8_e5m2;
+}
+#endif // USE_ROCM
+
+struct cuda_error : public std::runtime_error {
+    /**
+     * @brief Constructs a `cuda_error` object with the given `message`.
+     *
+     * @param message The error char array used to construct `cuda_error`
+     */
+    cuda_error(const char *message) : std::runtime_error(message) {}
+    /**
+     * @brief Constructs a `cuda_error` object with the given `message` string.
+     *
+     * @param message The `std::string` used to construct `cuda_error`
+     */
+    cuda_error(std::string const &message) : cuda_error{message.c_str()} {}
+};
+
+#define CHECK_CUDA_SUCCESS(cmd)                      \
+    do {                                             \
+        cudaError_t e = cmd;                         \
+        if (e != cudaSuccess) {                      \
+            std::stringstream _message;              \
+            auto s = cudaGetErrorString(e);          \
+            _message << std::string(s) + "\n"        \
+                     << __FILE__ << ':' << __LINE__; \
+            throw cuda_error(_message.str());        \
+        }                                            \
+    } while (0)
+
+#define CHECK_IS_CUDA(x) TORCH_CHECK(x.device().is_cuda(), #x " must be a CUDA tensor")
+#define CHECK_IS_CONTIGUOUS(x) TORCH_CHECK(x.is_contiguous(), #x " must be contiguous")
+#define CHECK_CUDA_INPUT(x) \
+    CHECK_IS_CUDA(x);       \
+    CHECK_IS_CONTIGUOUS(x)
+
+inline int getSMVersion() {
+    int device{-1};
+    CHECK_CUDA_SUCCESS(cudaGetDevice(&device));
+    int sm_major = 0;
+    int sm_minor = 0;
+    CHECK_CUDA_SUCCESS(cudaDeviceGetAttribute(&sm_major, cudaDevAttrComputeCapabilityMajor, device));
+    CHECK_CUDA_SUCCESS(cudaDeviceGetAttribute(&sm_minor, cudaDevAttrComputeCapabilityMinor, device));
+    return sm_major * 10 + sm_minor;
+}
+
+inline bool isDeviceType(const std::string &device_type) {
+    int deviceCount;
+    CHECK_CUDA_SUCCESS(cudaGetDeviceCount(&deviceCount));
+
+    int device_id = -1;
+    if (deviceCount >= 1) {
+        CHECK_CUDA_SUCCESS(cudaGetDevice(&device_id));
+    } else {
+        return false;
+    }
+
+    cudaDeviceProp prop;
+    CHECK_CUDA_SUCCESS(cudaGetDeviceProperties(&prop, device_id));
+    if (device_type == std::string(prop.name)) {
+        return true;
+    }
+    return false;
+}
+
+inline bool getBoolEnv(char const *name) {
+    char const *env = std::getenv(name);
+    return env && env[0] == '1' && env[1] == '\0';
+}
+
+inline bool getEnvEnablePDL() {
+    static std::once_flag flag;
+    static bool enablePDL = false;
+    std::call_once(flag, [&]() {
+        if (getSMVersion() >= 90) {
+            // PDL will be enabled by setting the env variables `TRTLLM_ENABLE_PDL` to `1`
+            enablePDL = getBoolEnv("TRTLLM_ENABLE_PDL");
+        }
+    });
+    return enablePDL;
+}
+
+// SGLANG_SHFL_XOR_* adapted from https://github.com/vllm-project/vllm/blob/v0.7.3/csrc/cuda_compat.h#L19-L28
+#ifndef USE_ROCM
+#define SGLANG_SHFL_XOR_SYNC(mask, var, lane_mask) __shfl_xor_sync((mask), (var), (lane_mask))
+#define SGLANG_SHFL_XOR_SYNC_WIDTH(mask, var, lane_mask, width) __shfl_xor_sync((mask), (var), (lane_mask), (width))
+#else
+#define SGLANG_SHFL_XOR_SYNC(mask, var, lane_mask) __shfl_xor((var), (lane_mask))
+#define SGLANG_SHFL_XOR_SYNC_WIDTH(mask, var, lane_mask, width) __shfl_xor((var), (lane_mask), (width))
+#endif
+
+#define DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FLOAT_FP16(pytorch_dtype, c_type, ...)               \
+    [&]() -> bool {                                                                          \
+        switch (pytorch_dtype) {                                                             \
+        case at::ScalarType::Float: {                                                        \
+            using c_type = float;                                                            \
+            return __VA_ARGS__();                                                            \
+        }                                                                                    \
+            _DISPATCH_CASE_F16(c_type, __VA_ARGS__)                                          \
+            _DISPATCH_CASE_BF16(c_type, __VA_ARGS__)                                         \
+        default:                                                                             \
+            std::ostringstream oss;                                                          \
+            oss << __PRETTY_FUNCTION__ << " failed to dispatch data type " << pytorch_dtype; \
+            TORCH_CHECK(false, oss.str());                                                   \
+            return false;                                                                    \
+        }                                                                                    \
+    }()
+
+#define DISPATCH_CASE_INTEGRAL_TYPES(...)                \
+    AT_DISPATCH_CASE(at::ScalarType::Byte, __VA_ARGS__)  \
+    AT_DISPATCH_CASE(at::ScalarType::Char, __VA_ARGS__)  \
+    AT_DISPATCH_CASE(at::ScalarType::Short, __VA_ARGS__) \
+    AT_DISPATCH_CASE(at::ScalarType::Int, __VA_ARGS__)   \
+    AT_DISPATCH_CASE(at::ScalarType::Long, __VA_ARGS__)
+
+#define DISPATCH_INTEGRAL_TYPES(TYPE, NAME, ...) \
+    AT_DISPATCH_SWITCH(TYPE, NAME, DISPATCH_CASE_INTEGRAL_TYPES(__VA_ARGS__))
+
+#define DISPATCH_CASE_FLOAT_TYPES(...)                   \
+    AT_DISPATCH_CASE(at::ScalarType::Float, __VA_ARGS__) \
+    AT_DISPATCH_CASE(at::ScalarType::Half, __VA_ARGS__)  \
+    AT_DISPATCH_CASE(at::ScalarType::BFloat16, __VA_ARGS__)
+
+#define DISPATCH_FLOAT_TYPES(TYPE, NAME, ...) AT_DISPATCH_SWITCH(TYPE, NAME, DISPATCH_CASE_FLOAT_TYPES(__VA_ARGS__))
+
+#define CEILDIV(x, y) (((x) + (y)-1) / (y))
+
+#ifndef USE_ROCM
+#define WARP_SIZE 32
+#else
+#if defined(__GFX9__) || !defined(__HIP_DEVICE_COMPILE__)
+#define WARP_SIZE 64
+#else
+#define WARP_SIZE 32
+#endif
+#endif
+
+#ifdef USE_ROCM
+
+#include "hip/hip_math_def.h"
+#include "hip/hip_vec_dtypes.h"
+
+#else
+
+template <typename srcDtype>
+__device__ __forceinline__ float castToFloat(srcDtype val) {
+    return static_cast<srcDtype>(val);
+}
+
+template <typename dstDtype>
+__device__ __forceinline__ dstDtype castFromFloat(float val) {
+    return static_cast<dstDtype>(val);
+}
+
+#endif
+
+// add FP8 support
+#ifndef USE_ROCM
+#include <c10/util/Float8_e4m3fn.h>
+using FP8_TYPE = c10::Float8_e4m3fn;
+C10_HOST_DEVICE constexpr auto FP8_E4M3_MAX = std::numeric_limits<FP8_TYPE>::max();
+#else // USE_ROCM
+#if HIP_FP8_TYPE_FNUZ
+#include <c10/util/Float8_e4m3fnuz.h>
+using FP8_TYPE = c10::Float8_e4m3fnuz;
+constexpr auto FP8_E4M3_MAX = 224.0f;
+#else
+#if HIP_FP8_TYPE_E4M3
+#include <c10/util/Float8_e4m3fn.h>
+using FP8_TYPE = c10::Float8_e4m3fn;
+C10_HOST_DEVICE constexpr auto FP8_E4M3_MAX = std::numeric_limits<FP8_TYPE>::max();
+#else
+#error "fp8 is not supported in this processor (arch < gfx942)."
+#endif // HIP_FP8_TYPE_E4M3
+#endif // HIP_FP8_TYPE_FNUZ
+#endif // USE_ROCM
+
+#define FULL_MASK 0xffffffff
+
+__device__ __forceinline__ float atomicMaxFloat(float *addr, float value) {
+#ifndef USE_ROCM
+    float old;
+    old = (value >= 0) ? __int_as_float(atomicMax((int *)addr, __float_as_int(value)))
+                       : __uint_as_float(atomicMin((unsigned int *)addr, __float_as_uint(value)));
+    return old;
+#else
+    int *addr_as_i = (int *)addr;
+    int old = *addr_as_i, assumed;
+    do {
+        assumed = old;
+        old = atomicCAS(addr_as_i, assumed, __float_as_int(fmaxf(value, __int_as_float(assumed))));
+    } while (assumed != old);
+    return __int_as_float(old);
+#endif
+}
+
+__device__ __forceinline__ float warpReduceMax(float value) {
+    value = fmaxf(value, __shfl_xor_sync(FULL_MASK, value, 16));
+    value = fmaxf(value, __shfl_xor_sync(FULL_MASK, value, 8));
+    value = fmaxf(value, __shfl_xor_sync(FULL_MASK, value, 4));
+    value = fmaxf(value, __shfl_xor_sync(FULL_MASK, value, 2));
+    value = fmaxf(value, __shfl_xor_sync(FULL_MASK, value, 1));
+    return value;
+}
+
+__device__ __forceinline__ float blockReduceMax(float value) {
+    static __shared__ float warpLevelMaxs[WARP_SIZE];
+    const int laneId = threadIdx.x % WARP_SIZE;
+    const int warpId = threadIdx.x / WARP_SIZE;
+
+    value = warpReduceMax(value);
+
+    if (laneId == 0) {
+        warpLevelMaxs[warpId] = value;
+    }
+    __syncthreads();
+
+    value = (threadIdx.x < blockDim.x / WARP_SIZE) ? warpLevelMaxs[laneId] : 0;
+    if (warpId == 0) {
+        value = warpReduceMax(value);
+    }
+
+    return value;
+}
+
+// Pads to a multiple of `alignment` rows.
+inline torch::Tensor pad_tensor(const torch::Tensor &tensor, int64_t alignment = 4, bool is_column_major = false) {
+    int64_t rows = tensor.size(0);
+    int64_t cols = tensor.size(1);
+    int64_t pad_rows = (alignment - (rows % alignment)) % alignment; // Compute padding size
+
+    if (pad_rows == 0) {
+        return tensor; // Already aligned
+    }
+
+    torch::Tensor padding = torch::zeros({pad_rows, cols}, tensor.options());
+    torch::Tensor tensor_padded = torch::cat({tensor, padding}, 0); // Pad along rows
+
+    // Ensure column-major layout
+    if (is_column_major) {
+        return tensor_padded.t().contiguous().t();
+    }
+    return tensor_padded;
+}
+
+// Get the next power of 2 of a number
+inline uint32_t next_pow2(uint32_t x) noexcept {
+    if (x <= 1) {
+        return 1;
+    }
+    return 1u << (32 - __builtin_clz(x - 1));
+}
+
+/*
+ * LDG Support
+ */
+#ifndef USE_ROCM
+#define SGLANG_LDG(arg) __ldg(arg)
+#else
+#define SGLANG_LDG(arg) *(arg)
+#endif

--- a/test/infiniop/libinfiniop/op_register.py
+++ b/test/infiniop/libinfiniop/op_register.py
@@ -4,7 +4,7 @@ from .structs import (
     infiniopOperatorDescriptor_t,
 )
 
-from ctypes import c_int32, c_void_p, c_size_t, POINTER, c_float
+from ctypes import c_int32, c_void_p, c_size_t, POINTER, c_float, c_bool
 
 
 class OpRegister:
@@ -759,6 +759,152 @@ def per_channel_quant_int8_(lib):
     lib.infiniopDestroyPerChannelQuantI8Descriptor.argtypes = [
         infiniopOperatorDescriptor_t,
     ]
+
+
+@OpRegister.operator
+def per_tensor_quant_fp8_(lib):
+    lib.infiniopCreatePerTensorQuantF8Descriptor.restype = c_int32
+    lib.infiniopCreatePerTensorQuantF8Descriptor.argtypes = [
+        infiniopHandle_t,
+        POINTER(infiniopOperatorDescriptor_t),
+        infiniopTensorDescriptor_t,
+        infiniopTensorDescriptor_t,
+        infiniopTensorDescriptor_t,
+        infiniopTensorDescriptor_t,
+        c_bool,
+    ]
+
+    lib.infiniopGetPerTensorQuantF8WorkspaceSize.restype = c_int32
+    lib.infiniopGetPerTensorQuantF8WorkspaceSize.argtypes = [
+        infiniopOperatorDescriptor_t,
+        POINTER(c_size_t),
+    ]
+
+    lib.infiniopPerTensorQuantF8.restype = c_int32
+    lib.infiniopPerTensorQuantF8.argtypes = [
+        infiniopOperatorDescriptor_t,
+        c_void_p,
+        c_size_t,
+        c_void_p,
+        c_void_p,
+        c_void_p,
+        c_void_p,
+        c_void_p,
+    ]
+
+    lib.infiniopDestroyPerTensorQuantF8Descriptor.restype = c_int32
+    lib.infiniopDestroyPerTensorQuantF8Descriptor.argtypes = [
+        infiniopOperatorDescriptor_t,
+    ]
+
+
+@OpRegister.operator
+def per_token_quant_fp8_(lib):
+    lib.infiniopCreatePerTokenQuantF8Descriptor.restype = c_int32
+    lib.infiniopCreatePerTokenQuantF8Descriptor.argtypes = [
+        infiniopHandle_t,
+        POINTER(infiniopOperatorDescriptor_t),
+        infiniopTensorDescriptor_t,
+        infiniopTensorDescriptor_t,
+        infiniopTensorDescriptor_t,
+        infiniopTensorDescriptor_t,
+    ]
+
+    lib.infiniopGetPerTokenQuantF8WorkspaceSize.restype = c_int32
+    lib.infiniopGetPerTokenQuantF8WorkspaceSize.argtypes = [
+        infiniopOperatorDescriptor_t,
+        POINTER(c_size_t),
+    ]
+
+    lib.infiniopPerTokenQuantF8.restype = c_int32
+    lib.infiniopPerTokenQuantF8.argtypes = [
+        infiniopOperatorDescriptor_t,
+        c_void_p,
+        c_size_t,
+        c_void_p,
+        c_void_p,
+        c_void_p,
+        c_void_p,
+        c_void_p,
+    ]
+
+    lib.infiniopDestroyPerTokenQuantF8Descriptor.restype = c_int32
+    lib.infiniopDestroyPerTokenQuantF8Descriptor.argtypes = [
+        infiniopOperatorDescriptor_t,
+    ]
+
+
+@OpRegister.operator
+def per_tensor_dequant_fp8_(lib):
+    lib.infiniopCreatePerTensorDequantF8Descriptor.restype = c_int32
+    lib.infiniopCreatePerTensorDequantF8Descriptor.argtypes = [
+        infiniopHandle_t,
+        POINTER(infiniopOperatorDescriptor_t),
+        infiniopTensorDescriptor_t,
+        infiniopTensorDescriptor_t,
+        infiniopTensorDescriptor_t,
+        infiniopTensorDescriptor_t,
+    ]
+
+    lib.infiniopGetPerTensorDequantF8WorkspaceSize.restype = c_int32
+    lib.infiniopGetPerTensorDequantF8WorkspaceSize.argtypes = [
+        infiniopOperatorDescriptor_t,
+        POINTER(c_size_t),
+    ]
+
+    lib.infiniopPerTensorDequantF8.restype = c_int32
+    lib.infiniopPerTensorDequantF8.argtypes = [
+        infiniopOperatorDescriptor_t,
+        c_void_p,
+        c_size_t,
+        c_void_p,
+        c_void_p,
+        c_void_p,
+        c_void_p,
+        c_void_p,
+    ]
+
+    lib.infiniopDestroyPerTensorDequantF8Descriptor.restype = c_int32
+    lib.infiniopDestroyPerTensorDequantF8Descriptor.argtypes = [
+        infiniopOperatorDescriptor_t,
+    ]
+
+
+@OpRegister.operator
+def per_token_dequant_fp8_(lib):
+    lib.infiniopCreatePerTokenDequantF8Descriptor.restype = c_int32
+    lib.infiniopCreatePerTokenDequantF8Descriptor.argtypes = [
+        infiniopHandle_t,
+        POINTER(infiniopOperatorDescriptor_t),
+        infiniopTensorDescriptor_t,
+        infiniopTensorDescriptor_t,
+        infiniopTensorDescriptor_t,
+        infiniopTensorDescriptor_t,
+    ]
+
+    lib.infiniopGetPerTokenDequantF8WorkspaceSize.restype = c_int32
+    lib.infiniopGetPerTokenDequantF8WorkspaceSize.argtypes = [
+        infiniopOperatorDescriptor_t,
+        POINTER(c_size_t),
+    ]
+
+    lib.infiniopPerTokenDequantF8.restype = c_int32
+    lib.infiniopPerTokenDequantF8.argtypes = [
+        infiniopOperatorDescriptor_t,
+        c_void_p,
+        c_size_t,
+        c_void_p,
+        c_void_p,
+        c_void_p,
+        c_void_p,
+        c_void_p,
+    ]
+
+    lib.infiniopDestroyPerTokenDequantF8Descriptor.restype = c_int32
+    lib.infiniopDestroyPerTokenDequantF8Descriptor.argtypes = [
+        infiniopOperatorDescriptor_t,
+    ]
+
 
 @OpRegister.operator
 def softplus_(lib):

--- a/test/infiniop/libinfiniop/op_register.py
+++ b/test/infiniop/libinfiniop/op_register.py
@@ -771,7 +771,6 @@ def per_tensor_quant_fp8_(lib):
         infiniopTensorDescriptor_t,
         infiniopTensorDescriptor_t,
         infiniopTensorDescriptor_t,
-        c_bool,
     ]
 
     lib.infiniopGetPerTensorQuantF8WorkspaceSize.restype = c_int32
@@ -789,6 +788,7 @@ def per_tensor_quant_fp8_(lib):
         c_void_p,
         c_void_p,
         c_void_p,
+        c_bool,
         c_void_p,
     ]
 

--- a/test/infiniop/per_tensor_dequant_fp8.py
+++ b/test/infiniop/per_tensor_dequant_fp8.py
@@ -1,0 +1,162 @@
+import torch
+import ctypes
+from ctypes import c_uint64
+from libinfiniop import (
+    LIBINFINIOP,
+    TestTensor,
+    get_test_devices,
+    check_error,
+    test_operator,
+    get_args,
+    debug,
+    get_tolerance,
+    profile_operation,
+    TestWorkspace,
+    InfiniDtype,
+    InfiniDtypeNames,
+    InfiniDeviceNames,
+    infiniopOperatorDescriptor_t,
+)
+from enum import Enum, auto
+
+# ==============================================================================
+#  Configuration (Internal Use Only)
+# ==============================================================================
+# These are not meant to be imported from other modules
+_TEST_CASES = [
+    # x_shape, symmetric
+    ((8, 8), True),
+    ((8, 128), True),
+    ((256, 1024), True),
+    ((1024, 2048), True),
+    ((2048, 2048), True),
+    ((4096, 2048), True),
+]
+
+
+# Data types used for testing
+_TENSOR_DTYPES = [InfiniDtype.BF16, InfiniDtype.F16, InfiniDtype.F32]
+
+# Tolerance map for different data types
+_TOLERANCE_MAP = {
+    InfiniDtype.F16: {"atol": 1e-3, "rtol": 1e-2},
+    InfiniDtype.BF16: {"atol": 1e-3, "rtol": 1e-2},
+    InfiniDtype.F32: {"atol": 3e-5, "rtol": 1e-5},
+}
+
+DEBUG = False
+PROFILE = False
+NUM_PRERUN = 10
+NUM_ITERATIONS = 1000
+
+
+FP8_E4M3_MAX = 448.0
+
+def dequantize_per_tensor_sym(x_packed, x_scale, dtype):
+    fake_qweight = x_packed.to(dtype)
+    dq_weight = fake_qweight * x_scale
+    return dq_weight
+
+
+def test(
+    handle,
+    device,
+    x_shape,
+    symmetric,
+    dtype=InfiniDtype.F16,
+    sync=None,
+):
+    if symmetric == False:
+        return 
+    print(
+        f"Testing Per Tensor Dequant Fp8 on {InfiniDeviceNames[device]} with x_shape:{x_shape}, symmetric:{symmetric} , dtype:{InfiniDtypeNames[dtype]}"
+    )
+    x = TestTensor(x_shape, None, dtype, device, mode="zeros")
+    x_packed = TestTensor(x_shape, None, InfiniDtype.F8, device, mode="float8_e4m3fn")
+    x_scale = TestTensor((1,), None, InfiniDtype.F32, device)
+
+    ans = dequantize_per_tensor_sym(x_packed.torch_tensor(), x_scale.torch_tensor(), x.torch_tensor().dtype)
+    
+    if symmetric:
+        x_zero = None
+    else:
+        x_zero = TestTensor((1,), None, InfiniDtype.F32, device)
+
+    if sync is not None:
+        sync()
+
+    descriptor = infiniopOperatorDescriptor_t()
+    check_error(
+        LIBINFINIOP.infiniopCreatePerTensorDequantF8Descriptor(
+            handle,
+            ctypes.byref(descriptor),
+            x.descriptor,
+            x_packed.descriptor,
+            x_scale.descriptor,
+            None if symmetric else x_zero.descriptor,
+        )
+    )
+
+    # Invalidate the shape and strides in the descriptor to prevent them from being directly used by the kernel
+
+    x_packed.destroy_desc()
+    x_scale.destroy_desc()
+    if symmetric == False:
+        x_zero.destroy_desc()
+
+    workspace_size = c_uint64(0)
+    check_error(
+        LIBINFINIOP.infiniopGetPerTensorDequantF8WorkspaceSize(
+            descriptor, ctypes.byref(workspace_size)
+        )
+    )
+    workspace = TestWorkspace(workspace_size.value, x.device)
+
+    def lib_per_tensor_dequant_fp8():
+        check_error(
+            LIBINFINIOP.infiniopPerTensorDequantF8(
+                descriptor,
+                workspace.data(),
+                workspace_size.value,
+                x.data(),
+                x_packed.data(),
+                x_scale.data(),
+                None if symmetric else x_zero.data(),
+                None,
+            )
+        )
+
+    lib_per_tensor_dequant_fp8()
+
+    if sync is not None:
+        sync()
+
+    atol, rtol = get_tolerance(_TOLERANCE_MAP, dtype)
+    if DEBUG:
+        debug(x.actual_tensor().float(), ans.float(), atol=atol, rtol=rtol)
+        
+    assert torch.allclose(x.actual_tensor().float(), ans.float(), atol=atol, rtol=rtol)
+
+    # Profiling workflow
+    if PROFILE:
+        # fmt: off
+        profile_operation("PyTorch", lambda: dequantize_per_tensor_sym(x_packed.torch_tensor(), x_scale.torch_tensor(), x.torch_tensor().dtype), device, NUM_PRERUN, NUM_ITERATIONS)
+        profile_operation("    lib", lambda: lib_per_tensor_dequant_fp8(), device, NUM_PRERUN, NUM_ITERATIONS)
+        # fmt: on
+
+    check_error(LIBINFINIOP.infiniopDestroyPerTensorDequantF8Descriptor(descriptor))
+
+
+if __name__ == "__main__":
+    args = get_args()
+
+    # Configure testing options
+    DEBUG = args.debug
+    PROFILE = args.profile
+    NUM_PRERUN = args.num_prerun
+    NUM_ITERATIONS = args.num_iterations
+
+    for device in get_test_devices(args):
+        test_operator(device, test, _TEST_CASES, _TENSOR_DTYPES)
+
+    print("\033[92mTest passed!\033[0m")

--- a/test/infiniop/per_tensor_quant_fp8.py
+++ b/test/infiniop/per_tensor_quant_fp8.py
@@ -1,0 +1,200 @@
+import torch
+import ctypes
+from ctypes import c_uint64
+from libinfiniop import (
+    LIBINFINIOP,
+    TestTensor,
+    get_test_devices,
+    check_error,
+    test_operator,
+    get_args,
+    debug,
+    get_tolerance,
+    profile_operation,
+    TestWorkspace,
+    InfiniDtype,
+    InfiniDtypeNames,
+    InfiniDeviceNames,
+    infiniopOperatorDescriptor_t,
+)
+from enum import Enum, auto
+
+# ==============================================================================
+#  Configuration (Internal Use Only)
+# ==============================================================================
+# These are not meant to be imported from other modules
+_TEST_CASES = [
+    # x_shape, symmetric, is_static
+    ((8, 8), True, False),
+    ((8, 128), True, False),
+    ((256, 1024), True, False),
+    ((1024, 2048), True, False),
+    ((2048, 2048), True, False),
+    ((4096, 2048), True, False),
+]
+
+
+# Data types used for testing
+_TENSOR_DTYPES = [InfiniDtype.BF16, InfiniDtype.F16, InfiniDtype.F32]
+
+# Tolerance map for different data types
+_TOLERANCE_MAP = {
+    InfiniDtype.F16: {"atol": 1e-3, "rtol": 5e-2},
+    InfiniDtype.BF16: {"atol": 1e-3, "rtol": 5e-2},
+    InfiniDtype.F32: {"atol": 3e-5, "rtol": 5e-3},
+}
+
+DEBUG = False
+PROFILE = False
+NUM_PRERUN = 10
+NUM_ITERATIONS = 1000
+
+
+FP8_E4M3_MAX = 448.0
+
+
+def per_tensor_quant_fp8_torch(x, symmetric):
+    if symmetric == False:
+        return
+    else:
+        absmax = x.flatten().abs().max()
+
+        if absmax == 0:
+            scale = torch.tensor(1.0, device=x.device, dtype=torch.float32)
+            q = torch.zeros_like(x, dtype=torch.float8_e4m3fn)
+            return q, scale, None
+
+        # 2. scale = absmax / FP8_MAX
+        scale = absmax / FP8_E4M3_MAX
+
+        # 3. 量化（注意：CUDA 里用的是 x * (1 / scale)）
+        inv_scale = 1.0 / scale
+        x_scaled = x * inv_scale
+
+        # 4. clip 到 FP8 可表示范围
+        x_clamped = torch.clamp(x_scaled, -FP8_E4M3_MAX, FP8_E4M3_MAX)
+
+        # 5. cast to fp8 e4m3
+        q = x_clamped.to(torch.float8_e4m3fn)
+
+        return q, scale.float(), None
+
+
+def test(
+    handle,
+    device,
+    x_shape,
+    symmetric,
+    is_static,
+    dtype=InfiniDtype.F16,
+    sync=None,
+):
+
+    print(
+        f"Testing Per Tensor Quant Fp8 on {InfiniDeviceNames[device]} with x_shape:{x_shape}, symmetric:{symmetric} , dtype:{InfiniDtypeNames[dtype]}"
+    )
+
+    x = TestTensor(x_shape, None, dtype, device)
+    x_p, x_s, x_z = per_tensor_quant_fp8_torch(x.torch_tensor(), symmetric)
+    x_packed = TestTensor(x_shape, None, InfiniDtype.F8, device, mode="zeros")
+    if is_static == False:
+        x_scale = TestTensor((1,), None, InfiniDtype.F32, device, mode="zeros")
+    else:
+        x_scale = TestTensor((1,), None, InfiniDtype.F32, device)
+    if symmetric:
+        x_zero = None
+    else:
+        x_zero = TestTensor((1,), None, InfiniDtype.F32, device)
+    if sync is not None:
+        sync()
+
+    descriptor = infiniopOperatorDescriptor_t()
+    check_error(
+        LIBINFINIOP.infiniopCreatePerTensorQuantF8Descriptor(
+            handle,
+            ctypes.byref(descriptor),
+            x_packed.descriptor,
+            x_scale.descriptor,
+            None if symmetric else x_zero.descriptor,
+            x.descriptor,
+            is_static,
+        )
+    )
+
+    # Invalidate the shape and strides in the descriptor to prevent them from being directly used by the kernel
+
+    x_packed.destroy_desc()
+    x_scale.destroy_desc()
+    if symmetric == False:
+        x_zero.destroy_desc()
+
+    workspace_size = c_uint64(0)
+    check_error(
+        LIBINFINIOP.infiniopGetPerTensorQuantF8WorkspaceSize(
+            descriptor, ctypes.byref(workspace_size)
+        )
+    )
+    workspace = TestWorkspace(workspace_size.value, x.device)
+
+    def lib_per_tensor_quant_fp8():
+        check_error(
+            LIBINFINIOP.infiniopPerTensorQuantF8(
+                descriptor,
+                workspace.data(),
+                workspace_size.value,
+                x_packed.data(),
+                x_scale.data(),
+                None if symmetric else x_zero.data(),
+                x.data(),
+                None,
+            )
+        )
+
+    lib_per_tensor_quant_fp8()
+
+    if sync is not None:
+        sync()
+
+    atol, rtol = get_tolerance(_TOLERANCE_MAP, dtype)
+    if DEBUG:
+        debug(x_packed.actual_tensor().float(), x_p.float(), atol=atol, rtol=rtol)
+        debug(x_scale.actual_tensor(), x_s, atol=atol, rtol=rtol)
+        if symmetric == False:
+            debug(x_zero.actual_tensor(), x_z, atol=atol, rtol=rtol)
+
+    if symmetric:
+        assert torch.allclose(
+            x_packed.actual_tensor().float(), x_p.float(), atol=2, rtol=2
+        ) and torch.allclose(x_scale.actual_tensor(), x_s, atol=atol, rtol=rtol)
+    else:
+        assert (
+            torch.allclose(
+                x_packed.actual_tensor().float(), x_p.float(), atol=2, rtol=2
+            )
+            and torch.allclose(x_scale.actual_tensor(), x_s, atol=atol, rtol=rtol)
+            and torch.allclose(x_zero.actual_tensor(), x_z, atol=atol, rtol=rtol)
+        )
+
+    # Profiling workflow
+    if PROFILE:
+        # fmt: off
+        profile_operation("PyTorch", lambda: per_tensor_quant_fp8_torch(x.torch_tensor(), symmetric), device, NUM_PRERUN, NUM_ITERATIONS)
+        profile_operation("    lib", lambda: lib_per_tensor_quant_fp8(), device, NUM_PRERUN, NUM_ITERATIONS)
+        # fmt: on
+
+    check_error(LIBINFINIOP.infiniopDestroyPerTensorQuantF8Descriptor(descriptor))
+
+
+if __name__ == "__main__":
+    args = get_args()
+
+    # Configure testing options
+    DEBUG = args.debug
+    PROFILE = args.profile
+    NUM_PRERUN = args.num_prerun
+    NUM_ITERATIONS = args.num_iterations
+
+    for device in get_test_devices(args):
+        test_operator(device, test, _TEST_CASES, _TENSOR_DTYPES)
+
+    print("\033[92mTest passed!\033[0m")

--- a/test/infiniop/per_tensor_quant_fp8.py
+++ b/test/infiniop/per_tensor_quant_fp8.py
@@ -25,12 +25,12 @@ from enum import Enum, auto
 # These are not meant to be imported from other modules
 _TEST_CASES = [
     # x_shape, symmetric, is_static
-    # ((8, 8), True, False),
-    # ((8, 128), True, False),
-    # ((256, 1024), True, False),
+    ((8, 8), True, False),
+    ((8, 128), True, False),
+    ((256, 1024), True, False),
     ((1024, 2048), True, False),
-    # ((2048, 2048), True, False),
-    # ((4096, 2048), True, False),
+    ((2048, 2048), True, False),
+    ((4096, 2048), True, False),
 ]
 
 
@@ -159,19 +159,19 @@ def test(
 
     atol, rtol = get_tolerance(_TOLERANCE_MAP, dtype)
     if DEBUG:
-        debug(x_packed.actual_tensor().float(), x_p.float(), atol=2, rtol=0)
+        debug(x_packed.actual_tensor().float(), x_p.float(), atol=32, rtol=0)
         debug(x_scale.actual_tensor(), x_s, atol=atol, rtol=rtol)
         if symmetric == False:
             debug(x_zero.actual_tensor(), x_z, atol=atol, rtol=rtol)
     
     if symmetric:
         assert torch.allclose(
-            x_packed.actual_tensor().float(), x_p.float(), atol=2, rtol=0
+            x_packed.actual_tensor().float(), x_p.float(), atol=32, rtol=0
         ) and torch.allclose(x_scale.actual_tensor(), x_s, atol=atol, rtol=rtol)
     else:
         assert (
             torch.allclose(
-                x_packed.actual_tensor().float(), x_p.float(), atol=2, rtol=0
+                x_packed.actual_tensor().float(), x_p.float(), atol=32, rtol=0
             )
             and torch.allclose(x_scale.actual_tensor(), x_s, atol=atol, rtol=rtol)
             and torch.allclose(x_zero.actual_tensor(), x_z, atol=atol, rtol=rtol)

--- a/test/infiniop/per_tensor_quant_fp8.py
+++ b/test/infiniop/per_tensor_quant_fp8.py
@@ -25,12 +25,12 @@ from enum import Enum, auto
 # These are not meant to be imported from other modules
 _TEST_CASES = [
     # x_shape, symmetric, is_static
-    ((8, 8), True, False),
-    ((8, 128), True, False),
-    ((256, 1024), True, False),
+    # ((8, 8), True, False),
+    # ((8, 128), True, False),
+    # ((256, 1024), True, False),
     ((1024, 2048), True, False),
-    ((2048, 2048), True, False),
-    ((4096, 2048), True, False),
+    # ((2048, 2048), True, False),
+    # ((4096, 2048), True, False),
 ]
 
 
@@ -53,28 +53,29 @@ NUM_ITERATIONS = 1000
 FP8_E4M3_MAX = 448.0
 
 
-def per_tensor_quant_fp8_torch(x, symmetric):
+def per_tensor_quant_fp8_torch(x, x_scale, symmetric, is_static):
     if symmetric == False:
         return
     else:
+        x = x.float()
+        if is_static:
+            x_q = x.mul(1 / x_scale)
+            x_clamped = torch.clamp(x_q, -FP8_E4M3_MAX, FP8_E4M3_MAX)
+            x_clamped = x_clamped.to(torch.float8_e4m3fn)
+            return x_clamped, x_scale, None
+        
         absmax = x.flatten().abs().max()
-
         if absmax == 0:
             scale = torch.tensor(1.0, device=x.device, dtype=torch.float32)
             q = torch.zeros_like(x, dtype=torch.float8_e4m3fn)
             return q, scale, None
 
-        # 2. scale = absmax / FP8_MAX
         scale = absmax / FP8_E4M3_MAX
-
-        # 3. 量化（注意：CUDA 里用的是 x * (1 / scale)）
         inv_scale = 1.0 / scale
         x_scaled = x * inv_scale
 
-        # 4. clip 到 FP8 可表示范围
         x_clamped = torch.clamp(x_scaled, -FP8_E4M3_MAX, FP8_E4M3_MAX)
 
-        # 5. cast to fp8 e4m3
         q = x_clamped.to(torch.float8_e4m3fn)
 
         return q, scale.float(), None
@@ -91,11 +92,10 @@ def test(
 ):
 
     print(
-        f"Testing Per Tensor Quant Fp8 on {InfiniDeviceNames[device]} with x_shape:{x_shape}, symmetric:{symmetric} , dtype:{InfiniDtypeNames[dtype]}"
+        f"Testing Per Tensor Quant Fp8 on {InfiniDeviceNames[device]} with x_shape:{x_shape}, symmetric:{symmetric}, is_static:{is_static} dtype:{InfiniDtypeNames[dtype]}"
     )
 
     x = TestTensor(x_shape, None, dtype, device)
-    x_p, x_s, x_z = per_tensor_quant_fp8_torch(x.torch_tensor(), symmetric)
     x_packed = TestTensor(x_shape, None, InfiniDtype.F8, device, mode="zeros")
     if is_static == False:
         x_scale = TestTensor((1,), None, InfiniDtype.F32, device, mode="zeros")
@@ -108,6 +108,8 @@ def test(
     if sync is not None:
         sync()
 
+    x_p, x_s, x_z = per_tensor_quant_fp8_torch(x.torch_tensor(), x_scale.torch_tensor(), symmetric, is_static)
+
     descriptor = infiniopOperatorDescriptor_t()
     check_error(
         LIBINFINIOP.infiniopCreatePerTensorQuantF8Descriptor(
@@ -117,7 +119,6 @@ def test(
             x_scale.descriptor,
             None if symmetric else x_zero.descriptor,
             x.descriptor,
-            is_static,
         )
     )
 
@@ -146,6 +147,7 @@ def test(
                 x_scale.data(),
                 None if symmetric else x_zero.data(),
                 x.data(),
+                is_static,
                 None,
             )
         )
@@ -157,19 +159,19 @@ def test(
 
     atol, rtol = get_tolerance(_TOLERANCE_MAP, dtype)
     if DEBUG:
-        debug(x_packed.actual_tensor().float(), x_p.float(), atol=atol, rtol=rtol)
+        debug(x_packed.actual_tensor().float(), x_p.float(), atol=2, rtol=0)
         debug(x_scale.actual_tensor(), x_s, atol=atol, rtol=rtol)
         if symmetric == False:
             debug(x_zero.actual_tensor(), x_z, atol=atol, rtol=rtol)
-
+    
     if symmetric:
         assert torch.allclose(
-            x_packed.actual_tensor().float(), x_p.float(), atol=2, rtol=2
+            x_packed.actual_tensor().float(), x_p.float(), atol=2, rtol=0
         ) and torch.allclose(x_scale.actual_tensor(), x_s, atol=atol, rtol=rtol)
     else:
         assert (
             torch.allclose(
-                x_packed.actual_tensor().float(), x_p.float(), atol=2, rtol=2
+                x_packed.actual_tensor().float(), x_p.float(), atol=2, rtol=0
             )
             and torch.allclose(x_scale.actual_tensor(), x_s, atol=atol, rtol=rtol)
             and torch.allclose(x_zero.actual_tensor(), x_z, atol=atol, rtol=rtol)
@@ -178,7 +180,7 @@ def test(
     # Profiling workflow
     if PROFILE:
         # fmt: off
-        profile_operation("PyTorch", lambda: per_tensor_quant_fp8_torch(x.torch_tensor(), symmetric), device, NUM_PRERUN, NUM_ITERATIONS)
+        profile_operation("PyTorch", lambda: per_tensor_quant_fp8_torch(x.torch_tensor(), x_scale.torch_tensor(), symmetric, is_static), device, NUM_PRERUN, NUM_ITERATIONS)
         profile_operation("    lib", lambda: lib_per_tensor_quant_fp8(), device, NUM_PRERUN, NUM_ITERATIONS)
         # fmt: on
 

--- a/test/infiniop/per_token_dequant_fp8.py
+++ b/test/infiniop/per_token_dequant_fp8.py
@@ -1,0 +1,164 @@
+import torch
+import ctypes
+from ctypes import c_uint64
+from libinfiniop import (
+    LIBINFINIOP,
+    TestTensor,
+    get_test_devices,
+    check_error,
+    test_operator,
+    get_args,
+    debug,
+    get_tolerance,
+    profile_operation,
+    TestWorkspace,
+    InfiniDtype,
+    InfiniDtypeNames,
+    InfiniDeviceNames,
+    infiniopOperatorDescriptor_t,
+)
+from enum import Enum, auto
+
+# ==============================================================================
+#  Configuration (Internal Use Only)
+# ==============================================================================
+# These are not meant to be imported from other modules
+_TEST_CASES = [
+    # x_shape, symmetric
+    ((8, 8), True),
+    ((8, 128), True),
+    ((256, 1024), True),
+    ((1024, 2048), True),
+    ((2048, 2048), True),
+    ((4096, 2048), True),
+]
+
+
+# Data types used for testing
+_TENSOR_DTYPES = [InfiniDtype.BF16, InfiniDtype.F16, InfiniDtype.F32]
+
+
+# Tolerance map for different data types
+_TOLERANCE_MAP = {
+    InfiniDtype.F16: {"atol": 1e-3, "rtol": 1e-2},
+    InfiniDtype.BF16: {"atol": 1e-3, "rtol": 1e-2},
+    InfiniDtype.F32: {"atol": 3e-5, "rtol": 1e-5},
+}
+
+DEBUG = False
+PROFILE = False
+NUM_PRERUN = 10
+NUM_ITERATIONS = 1000
+
+
+FP8_E4M3_MAX = 448.0
+
+
+def dequantize_per_token_sym(x_packed, x_scale, dtype):
+    fake_qweight = x_packed.to(dtype)
+    dq_weight = fake_qweight * x_scale
+    return dq_weight
+
+
+def test(
+    handle,
+    device,
+    x_shape,
+    symmetric,
+    dtype=InfiniDtype.F16,
+    sync=None,
+):
+
+    print(
+        f"Testing Per Token Dequant Fp8 on {InfiniDeviceNames[device]} with x_shape:{x_shape}, symmetric:{symmetric} , dtype:{InfiniDtypeNames[dtype]}"
+    )
+    num_tokens, hidden_dim = x_shape
+
+    x = TestTensor(x_shape, None, dtype, device, mode="zeros")
+    x_packed = TestTensor(x_shape, None, InfiniDtype.F8, device, mode="float8_e4m3fn")
+    x_scale = TestTensor((num_tokens, 1), None, InfiniDtype.F32, device)
+
+    ans = dequantize_per_token_sym(x_packed.torch_tensor(), x_scale.torch_tensor(), x.torch_tensor().dtype)
+
+    if symmetric:
+        x_zero = None
+    else:
+        x_zero = TestTensor((num_tokens, 1), None, InfiniDtype.F32, device)
+    if sync is not None:
+        sync()
+
+    descriptor = infiniopOperatorDescriptor_t()
+    check_error(
+        LIBINFINIOP.infiniopCreatePerTokenDequantF8Descriptor(
+            handle,
+            ctypes.byref(descriptor),
+            x.descriptor,
+            x_packed.descriptor,
+            x_scale.descriptor,
+            None if symmetric else x_zero.descriptor,
+        )
+    )
+
+    # Invalidate the shape and strides in the descriptor to prevent them from being directly used by the kernel
+
+    x_packed.destroy_desc()
+    x_scale.destroy_desc()
+    if symmetric == False:
+        x_zero.destroy_desc()
+
+    workspace_size = c_uint64(0)
+    check_error(
+        LIBINFINIOP.infiniopGetPerTokenDequantF8WorkspaceSize(
+            descriptor, ctypes.byref(workspace_size)
+        )
+    )
+    workspace = TestWorkspace(workspace_size.value, x.device)
+
+    def lib_per_token_dequant_fp8():
+        check_error(
+            LIBINFINIOP.infiniopPerTokenDequantF8(
+                descriptor,
+                workspace.data(),
+                workspace_size.value,
+                x.data(),
+                x_packed.data(),
+                x_scale.data(),
+                None if symmetric else x_zero.data(),
+                None,
+            )
+        )
+
+    lib_per_token_dequant_fp8()
+
+    if sync is not None:
+        sync()
+
+    atol, rtol = get_tolerance(_TOLERANCE_MAP, dtype)
+    if DEBUG:
+        debug(x.actual_tensor().float(), ans.float(), atol=atol, rtol=rtol)
+        
+    assert torch.allclose(x.actual_tensor().float(), ans.float(), atol=atol, rtol=rtol)
+
+    # Profiling workflow
+    if PROFILE:
+        # fmt: off
+        profile_operation("PyTorch", lambda: dequantize_per_token_sym(x_packed.torch_tensor(), x_scale.torch_tensor(), x.torch_tensor().dtype), device, NUM_PRERUN, NUM_ITERATIONS)
+        profile_operation("    lib", lambda: lib_per_token_dequant_fp8(), device, NUM_PRERUN, NUM_ITERATIONS)
+        # fmt: on
+
+    check_error(LIBINFINIOP.infiniopDestroyPerTokenDequantF8Descriptor(descriptor))
+
+
+if __name__ == "__main__":
+    args = get_args()
+
+    # Configure testing options
+    DEBUG = args.debug
+    PROFILE = args.profile
+    NUM_PRERUN = args.num_prerun
+    NUM_ITERATIONS = args.num_iterations
+
+    for device in get_test_devices(args):
+        test_operator(device, test, _TEST_CASES, _TENSOR_DTYPES)
+
+    print("\033[92mTest passed!\033[0m")

--- a/test/infiniop/per_token_quant_fp8.py
+++ b/test/infiniop/per_token_quant_fp8.py
@@ -1,0 +1,215 @@
+import torch
+import ctypes
+from ctypes import c_uint64
+from libinfiniop import (
+    LIBINFINIOP,
+    TestTensor,
+    get_test_devices,
+    check_error,
+    test_operator,
+    get_args,
+    debug,
+    get_tolerance,
+    profile_operation,
+    TestWorkspace,
+    InfiniDtype,
+    InfiniDtypeNames,
+    InfiniDeviceNames,
+    infiniopOperatorDescriptor_t,
+)
+from enum import Enum, auto
+
+# ==============================================================================
+#  Configuration (Internal Use Only)
+# ==============================================================================
+# These are not meant to be imported from other modules
+_TEST_CASES = [
+    # x_shape, symmetric
+    ((8, 8), True),
+    ((8, 128), True),
+    ((256, 1024), True),
+    ((1024, 2048), True),
+    ((2048, 2048), True),
+    ((4096, 2048), True),
+]
+
+
+# Data types used for testing
+_TENSOR_DTYPES = [InfiniDtype.BF16, InfiniDtype.F16, InfiniDtype.F32]
+
+
+# Tolerance map for different data types
+_TOLERANCE_MAP = {
+    InfiniDtype.F16: {"atol": 1e-3, "rtol": 5e-2},
+    InfiniDtype.BF16: {"atol": 1e-3, "rtol": 5e-2},
+    InfiniDtype.F32: {"atol": 3e-3, "rtol": 5e-3},
+}
+
+DEBUG = False
+PROFILE = False
+NUM_PRERUN = 10
+NUM_ITERATIONS = 1000
+
+
+FP8_E4M3_MAX = 448.0
+
+
+def per_token_quant_fp8_torch(x, symmetric):
+    if symmetric == False:
+        return
+    else:
+        assert x.dim() == 2, "per-token quant expects [num_tokens, hidden_dim]"
+
+        # ------------------------------------------------------------
+        # Pass-1: per-token absmax (对齐 CUDA 的 warpReduceMax)
+        # ------------------------------------------------------------
+        # CUDA: max_value = max_j |x[token_id, j]|
+        absmax = x.abs().amax(dim=1)  # [num_tokens]
+
+        # ------------------------------------------------------------
+        # scale = absmax / FP8_E4M3_MAX
+        # CUDA 中 scale 是 per-token 写入 output_s[token_id]
+        # ------------------------------------------------------------
+        scale = absmax / FP8_E4M3_MAX  # [num_tokens]
+
+        inv_scale = 1.0 / scale
+        inv_scale[scale == 0] = float("inf")  # [num_tokens]
+
+        # ------------------------------------------------------------
+        # Pass-2: x * inv_scale
+        # CUDA: val = input * scale_inv
+        # ------------------------------------------------------------
+        x_scaled = x * inv_scale.unsqueeze(1)  # broadcast to [N, H]
+
+        # ------------------------------------------------------------
+        # clip 到 FP8 E4M3 可表示范围
+        # CUDA: fmaxf(fminf(val, FP8_E4M3_MAX), -FP8_E4M3_MAX)
+        # ------------------------------------------------------------
+        x_clamped = torch.clamp(x_scaled, -FP8_E4M3_MAX, FP8_E4M3_MAX)
+
+        # ------------------------------------------------------------
+        # cast to FP8
+        # CUDA: static_cast<DST_DTYPE>(val)
+        # ------------------------------------------------------------
+        q = x_clamped.to(torch.float8_e4m3fn)
+
+        return q, scale.float(), None
+
+
+def test(
+    handle,
+    device,
+    x_shape,
+    symmetric,
+    dtype=InfiniDtype.F16,
+    sync=None,
+):
+
+    print(
+        f"Testing Per Token Quant Fp8 on {InfiniDeviceNames[device]} with x_shape:{x_shape}, symmetric:{symmetric} , dtype:{InfiniDtypeNames[dtype]}"
+    )
+    num_tokens, hidden_dim = x_shape
+
+    x = TestTensor(x_shape, None, dtype, device)
+    x_p, x_s, x_z = per_token_quant_fp8_torch(x.torch_tensor(), symmetric)
+    x_packed = TestTensor(x_shape, None, InfiniDtype.F8, device, mode="zeros")
+    x_scale = TestTensor((num_tokens, 1), None, InfiniDtype.F32, device)
+
+    if symmetric:
+        x_zero = None
+    else:
+        x_zero = TestTensor((num_tokens, 1), None, InfiniDtype.F32, device)
+    if sync is not None:
+        sync()
+
+    descriptor = infiniopOperatorDescriptor_t()
+    check_error(
+        LIBINFINIOP.infiniopCreatePerTokenQuantF8Descriptor(
+            handle,
+            ctypes.byref(descriptor),
+            x_packed.descriptor,
+            x_scale.descriptor,
+            None if symmetric else x_zero.descriptor,
+            x.descriptor,
+        )
+    )
+
+    # Invalidate the shape and strides in the descriptor to prevent them from being directly used by the kernel
+
+    x_packed.destroy_desc()
+    x_scale.destroy_desc()
+    if symmetric == False:
+        x_zero.destroy_desc()
+
+    workspace_size = c_uint64(0)
+    check_error(
+        LIBINFINIOP.infiniopGetPerTokenQuantF8WorkspaceSize(
+            descriptor, ctypes.byref(workspace_size)
+        )
+    )
+    workspace = TestWorkspace(workspace_size.value, x.device)
+
+    def lib_per_token_quant_fp8():
+        check_error(
+            LIBINFINIOP.infiniopPerTokenQuantF8(
+                descriptor,
+                workspace.data(),
+                workspace_size.value,
+                x_packed.data(),
+                x_scale.data(),
+                None if symmetric else x_zero.data(),
+                x.data(),
+                None,
+            )
+        )
+
+    lib_per_token_quant_fp8()
+
+    if sync is not None:
+        sync()
+
+    atol, rtol = get_tolerance(_TOLERANCE_MAP, dtype)
+    if DEBUG:
+        debug(x_packed.actual_tensor().float(), x_p.float(), atol=atol, rtol=rtol)
+        debug(x_scale.actual_tensor(), x_s, atol=atol, rtol=rtol)
+        if symmetric == False:
+            debug(x_zero.actual_tensor(), x_z, atol=atol, rtol=rtol)
+
+    # print(x_s - x_scale.actual_tensor())
+    # print(x_packed.actual_tensor().float() - x_p.float())
+    if symmetric:
+        assert torch.allclose(
+            x_packed.actual_tensor().float(), x_p.float(), atol=2, rtol=2
+        ) and torch.allclose(x_scale.actual_tensor(), x_s, atol=atol, rtol=rtol)
+    else:
+        assert (
+            torch.allclose(
+                x_packed.actual_tensor().float(), x_p.float(), atol=2, rtol=2
+            )
+            and torch.allclose(x_scale.actual_tensor(), x_s, atol=atol, rtol=rtol)
+            and torch.allclose(x_zero.actual_tensor(), x_z, atol=atol, rtol=rtol)
+        )
+
+    # Profiling workflow
+    if PROFILE:
+        # fmt: off
+        profile_operation("PyTorch", lambda: per_token_quant_fp8_torch(x.torch_tensor(), symmetric), device, NUM_PRERUN, NUM_ITERATIONS)
+        profile_operation("    lib", lambda: lib_per_token_quant_fp8(), device, NUM_PRERUN, NUM_ITERATIONS)
+        # fmt: on
+
+    check_error(LIBINFINIOP.infiniopDestroyPerTokenQuantF8Descriptor(descriptor))
+
+
+if __name__ == "__main__":
+    args = get_args()
+
+    # Configure testing options
+    DEBUG = args.debug
+    PROFILE = args.profile
+    NUM_PRERUN = args.num_prerun
+    NUM_ITERATIONS = args.num_iterations
+
+    for device in get_test_devices(args):
+        test_operator(device, test, _TEST_CASES, _TENSOR_DTYPES)
+
+    print("\033[92mTest passed!\033[0m")

--- a/test/infiniop/per_token_quant_fp8.py
+++ b/test/infiniop/per_token_quant_fp8.py
@@ -59,38 +59,15 @@ def per_token_quant_fp8_torch(x, symmetric):
         return
     else:
         assert x.dim() == 2, "per-token quant expects [num_tokens, hidden_dim]"
-
-        # ------------------------------------------------------------
-        # Pass-1: per-token absmax (对齐 CUDA 的 warpReduceMax)
-        # ------------------------------------------------------------
-        # CUDA: max_value = max_j |x[token_id, j]|
         absmax = x.abs().amax(dim=1)  # [num_tokens]
-
-        # ------------------------------------------------------------
-        # scale = absmax / FP8_E4M3_MAX
-        # CUDA 中 scale 是 per-token 写入 output_s[token_id]
-        # ------------------------------------------------------------
         scale = absmax / FP8_E4M3_MAX  # [num_tokens]
 
         inv_scale = 1.0 / scale
         inv_scale[scale == 0] = float("inf")  # [num_tokens]
 
-        # ------------------------------------------------------------
-        # Pass-2: x * inv_scale
-        # CUDA: val = input * scale_inv
-        # ------------------------------------------------------------
         x_scaled = x * inv_scale.unsqueeze(1)  # broadcast to [N, H]
 
-        # ------------------------------------------------------------
-        # clip 到 FP8 E4M3 可表示范围
-        # CUDA: fmaxf(fminf(val, FP8_E4M3_MAX), -FP8_E4M3_MAX)
-        # ------------------------------------------------------------
         x_clamped = torch.clamp(x_scaled, -FP8_E4M3_MAX, FP8_E4M3_MAX)
-
-        # ------------------------------------------------------------
-        # cast to FP8
-        # CUDA: static_cast<DST_DTYPE>(val)
-        # ------------------------------------------------------------
         q = x_clamped.to(torch.float8_e4m3fn)
 
         return q, scale.float(), None
@@ -170,21 +147,19 @@ def test(
 
     atol, rtol = get_tolerance(_TOLERANCE_MAP, dtype)
     if DEBUG:
-        debug(x_packed.actual_tensor().float(), x_p.float(), atol=atol, rtol=rtol)
+        debug(x_packed.actual_tensor().float(), x_p.float(), atol=32, rtol=0)
         debug(x_scale.actual_tensor(), x_s, atol=atol, rtol=rtol)
         if symmetric == False:
             debug(x_zero.actual_tensor(), x_z, atol=atol, rtol=rtol)
 
-    # print(x_s - x_scale.actual_tensor())
-    # print(x_packed.actual_tensor().float() - x_p.float())
     if symmetric:
         assert torch.allclose(
-            x_packed.actual_tensor().float(), x_p.float(), atol=2, rtol=2
+            x_packed.actual_tensor().float(), x_p.float(), atol=32, rtol=0
         ) and torch.allclose(x_scale.actual_tensor(), x_s, atol=atol, rtol=rtol)
     else:
         assert (
             torch.allclose(
-                x_packed.actual_tensor().float(), x_p.float(), atol=2, rtol=2
+                x_packed.actual_tensor().float(), x_p.float(), atol=32, rtol=0
             )
             and torch.allclose(x_scale.actual_tensor(), x_s, atol=atol, rtol=rtol)
             and torch.allclose(x_zero.actual_tensor(), x_z, atol=atol, rtol=rtol)


### PR DESCRIPTION

<img width="2046" height="960" alt="76b7a941-7365-43a2-980e-e4825d3098ee" src="https://github.com/user-attachments/assets/a76dedd1-c559-4e55-92ef-6eec92a3cfe2" />
<img width="2558" height="1145" alt="c2eaca64-de64-499c-aa39-b21a64f14325" src="https://github.com/user-attachments/assets/aa3066d3-59cd-4728-8e90-d91ea2a42b9f" />
上面是dequant算子，下面是quant算子
<img width="2697" height="1161" alt="94cd8baa-f649-403f-9d98-f19d62dd9a71" src="https://github.com/user-attachments/assets/48072f14-664c-4841-b116-35958d0c7fb3" />
<img width="2328" height="963" alt="b60c2809-8d64-49a9-a3c3-6f8387c3602c" src="https://github.com/user-attachments/assets/246db9ab-6ce8-4e65-b4f9-8fa054306314" />




